### PR TITLE
Reformat Maven POM and assembly XML, no functional changes

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -1,7 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>xalan</groupId>
     <artifactId>xalan-project</artifactId>
@@ -9,17 +10,18 @@
   </parent>
 
   <artifactId>distribution</artifactId>
-  
-<!-- PROBLEM: Something has been overwriting this pom. I don't know
-       whether making the packaging "pom" had anything to do with that,
-       but changing it may have helped. 
+
+  <!--
+    PROBLEM: Something has been overwriting this pom. I don't know whether making the packaging "pom" had anything to do
+    with that, but changing it may have helped. 
   -->
   <packaging>jar</packaging>
- 
+
   <name>distribution</name>
-  
-  <!-- NOTE: These dependency declarations are only required to sort
-       this project to the end of the queue in the multimodule build.
+
+  <!--
+    NOTE: These dependency declarations are only required to sort this project to the end of the queue in the
+    multimodule build.
   -->
   <dependencies>
     <dependency>
@@ -38,12 +40,12 @@
       <version>2.7.3</version>
     </dependency>
   </dependencies>
- 
+
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-	<version>3.6.0</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>distro-assembly</id>
@@ -59,8 +61,6 @@
           </execution>
         </executions>
       </plugin>
-
-
 
     </plugins>
   </build>

--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -1,12 +1,13 @@
-<!-- Maven assembly plugin configuration for executable packaging 
-     See https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#module-binaries
-     TODO: Should include xercesImpl and xml-apis jarfiles? 
-	Not regex, bcel, commons
-	And those should be moved to xalan-X_version/
+<!--
+  Maven assembly plugin configuration for executable packaging.
+  See https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#module-binaries.
+  TODO: Should include xercesImpl and xml-apis jarfiles? 
+  Not regex, bcel, commons.
+  And those should be moved to xalan-X_version/.
 -->
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
   <id>bin</id>
   <formats>
     <format>zip</format>
@@ -28,10 +29,9 @@
       </binaries>
     </moduleSet>
   </moduleSets>
-  <!-- Should also include source for all the samples, and
-       all the documentation, for emulation of
-       Ant behavior. Rename site to docs for back-compatibility.
-       Should pick up version from variable...?
+  <!--
+    Should also include source for all the samples, and all the documentation, for emulation of Ant behavior. Rename
+    site to docs for back-compatibility. Should pick up version from variable...?
   -->
   <fileSets>
     <fileSet>
@@ -43,8 +43,8 @@
       <directory>../samples</directory>
       <outputDirectory>${project.parent.name}_${project.parent.version}/samples</outputDirectory>
       <excludes>
-	<exclude>target/**</exclude>
-	<exclude>src/site/**</exclude>
+        <exclude>target/**</exclude>
+        <exclude>src/site/**</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <packaging>pom</packaging>
-  <!-- KNOWN ISSUES:
-       "Production" jar/tar files?
-       xalan-test integration
-
-NOTE: To get dependency tree from a multi-module project, use the 
-command "mvn compile dependency:tree" so everything is in scope.
-  -->
-  
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <!--
+    KNOWN ISSUES:
+    "Production" jar/tar files?
+    xalan-test integration
+    
+    NOTE: To get dependency tree from a multi-module project, use the command "mvn compile dependency:tree" so
+    everything is in scope.
+  -->
+
   <groupId>xalan</groupId>
   <artifactId>xalan-project</artifactId>
   <version>2.7.3</version>
+  <packaging>pom</packaging>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -26,229 +29,233 @@ command "mvn compile dependency:tree" so everything is in scope.
     <module>xalan</module>
     <module>samples</module>
     <module>xalan2jtaglet</module>
-    <!-- The binary mode of maven-assembly-plugin needs to run after all the
-	 other modules have created their artifacts. Standard solution to
-	 achieve this sequencing is to make it a separate module which
-	 depends on all the others. See
-	 https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#module-binaries
-	 -->
+    <!--
+      The binary mode of maven-assembly-plugin needs to run after all the other modules have created their artifacts.
+      Standard solution to achieve this sequencing is to make it a separate module which depends on all the others.
+      See https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#module-binaries.
+    -->
     <module>distribution</module>
   </modules>
 
-
   <build>
     <pluginManagement>
-      <!-- Standardized configuration for plugins used by child modules,
-	   though not invoked by parent module -->
+      <!-- Standardized configuration for plugins used by child modules, though not invoked by parent module -->
       <plugins>
-	<!-- Copy produced jarfile up to xalan-java/build/,
-	     renaming to remove the version number, for
-	     backward compatibility with things build for the 
-	     Ant builds. 
-	-->
-	<plugin>
+        <!--
+          Copy produced jarfile up to xalan-java/build/, renaming to remove the version number, for backward
+          compatibility with things build for the Ant builds. 
+        -->
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <executions>
-            <execution>             
+            <execution>
               <id>copy-artifact</id>
               <phase>package</phase>
               <goals>
-		<goal>copy</goal>
+                <goal>copy</goal>
               </goals>
               <configuration>
-		<artifactItems>
-		  <artifactItem>
-		    <!-- Copy built artifact to ../build -->
+                <artifactItems>
+                  <artifactItem>
+                    <!-- Copy built artifact to ../build -->
                     <groupId>${project.groupId}</groupId>
                     <artifactId>${project.artifactId}</artifactId>
                     <version>${project.version}</version>
                     <type>${project.packaging}</type>
-		  </artifactItem>
-		  <artifactItem>
-		    <!-- Also copy without the "-${project.version}" suffix
-			 (but with the filetype), for backward compatibility
-			 with Ant build's behavior
-		    -->
+                  </artifactItem>
+                  <artifactItem>
+                    <!--
+                      Also copy without the "-${project.version}" suffix (but with the filetype), for backward
+                      compatibility with Ant build's behavior
+                    -->
                     <groupId>${project.groupId}</groupId>
                     <artifactId>${project.artifactId}</artifactId>
                     <version>${project.version}</version>
                     <type>${project.packaging}</type>
-		    <!-- stripVersion does not seem to do what's needed, so: -->
-		    <destFileName>${project.artifactId}.${project.packaging}</destFileName>
-		  </artifactItem>
-		</artifactItems>
-		<outputDirectory>../build</outputDirectory>
+                    <!-- stripVersion does not seem to do what's needed, so: -->
+                    <destFileName>${project.artifactId}.${project.packaging}</destFileName>
+                  </artifactItem>
+                </artifactItems>
+                <outputDirectory>../build</outputDirectory>
               </configuration>
             </execution>
           </executions>
-	</plugin>
+        </plugin>
       </plugins>
     </pluginManagement>
 
     <sourceDirectory>src/main/java</sourceDirectory>
     <resources>
       <resource>
-	<directory>META-INF</directory>
-	<includes>
-	  <include>LICENSE.txt</include>
-	  <include>NOTICE.txt</include>
-	</includes>
+        <directory>META-INF</directory>
+        <includes>
+          <include>LICENSE.txt</include>
+          <include>NOTICE.txt</include>
+        </includes>
       </resource>
       <resource>
-	<directory>resources</directory>
-	<includes>
-	  <include>**/*.properties</include>
-	</includes>
+        <directory>resources</directory>
+        <includes>
+          <include>**/*.properties</include>
+        </includes>
       </resource>
     </resources>
     <plugins>
       <plugin>
-	<artifactId>maven-compiler-plugin</artifactId>
-	<version>3.8.1</version>
-	<configuration>
-	  <source>1.8</source>
-	  <target>1.8</target>
-	</configuration>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
       </plugin>
 
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-shade-plugin</artifactId>
-	<version>3.5.0</version>
-	<executions>
-	  <execution>
-	    <phase>package</phase>
-	    <goals>
-	      <goal>shade</goal>
-	    </goals>
-	    <configuration>
-	      <artifactSet>
-		<excludes>
-		  <!-- Their examples -->
-		  <exclude>junit:junit</exclude>
-		  <exclude>jmock:*</exclude>
-		  <exclude>*:xml-apis</exclude>
-		  <exclude>org.apache.maven:lib:tests</exclude>
-		  <!-- What I think I need to exclude -->
-		  <exclude>com.github.vbmacher:java-cup</exclude>
-		  <exclude>commons-logging:commons-logging</exclude>
-		  <exclude>javax:*</exclude>
-		</excludes>
-	      </artifactSet>
-	    </configuration>
-	  </execution>
-	</executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <excludes>
+                  <!-- Their examples -->
+                  <exclude>junit:junit</exclude>
+                  <exclude>jmock:*</exclude>
+                  <exclude>*:xml-apis</exclude>
+                  <exclude>org.apache.maven:lib:tests</exclude>
+                  <!-- What I think I need to exclude -->
+                  <exclude>com.github.vbmacher:java-cup</exclude>
+                  <exclude>commons-logging:commons-logging</exclude>
+                  <exclude>javax:*</exclude>
+                </excludes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-site-plugin</artifactId>
-	<version>3.7.1</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
       </plugin>
 
-      <!-- Maven finds this without assistance, but grumbles about
-	   unspecified plugin version, so... -->
+      <!-- Maven finds this without assistance, but grumbles about unspecified plugin version, so... -->
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-project-info-reports-plugin</artifactId>
-	<version>3.4.5</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.4.5</version>
       </plugin>
 
-      <!-- During cleaning phase, empty the ./build directory, which
-	   is normally not present except in the parent module. 
+      <!--
+        During cleaning phase, empty the ./build directory, which is normally not present except in the parent module. 
       -->
       <plugin>
-	<artifactId>maven-clean-plugin</artifactId>
-	<version>3.3.1</version>
-	<configuration>
-	  <filesets>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.3.1</version>
+        <configuration>
+          <filesets>
             <fileset>
               <directory>./build</directory>
               <followSymlinks>false</followSymlinks>
             </fileset>
-	  </filesets>
-	</configuration>
+          </filesets>
+        </configuration>
       </plugin>
 
-      <!-- StyleBook processing.
-	   NOTE: Stylebook as it has been calls System.exit() on its way out.
-	   That means running exec:java will malfunction since it'll blow out
-	   the entire Maven process. Workaround is to invoke Stylebook from
-	   the command line with exec:exec. Proper fix is to remove that
-	   behavior from Stylebook's code and have it exit more cleanly,
-	   or to have exec optionally fork a process for java.
-	   The latter is in development.
-	   -->
+      <!--
+        StyleBook processing.
+        
+        NOTE: Stylebook as it has been calls System.exit() on its way out. That means running exec:java will malfunction
+        since it'll blow out the entire Maven process. Workaround is to invoke Stylebook from the command line with
+        exec:exec. Proper fix is to remove that behavior from Stylebook's code and have it exit more cleanly, or to have
+        exec optionally fork a process for java. The latter is in development.
+      -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.1.0</version>
-	<inherited>false</inherited> <!-- Run only in xalan-project parent -->
+        <inherited>false</inherited> <!-- Run only in xalan-project parent -->
         <executions>
           <execution>
-	    <id>Xalan2 design documentation</id>
+            <id>Xalan2 design documentation</id>
             <phase>package</phase>
             <goals>
-	      <goal>exec</goal>
+              <goal>exec</goal>
             </goals>
-	    <configuration>
-	      <executable>java</executable>
-	      <commandlineArgs>-cp ${stylebook.classpath} org.apache.stylebook.StyleBook loaderConfig=sbk:/style/loaderdesign.xml targetDirectory=./target/site/design/ ./stylebook/sources/xalandesign.xml ./stylebook/style</commandlineArgs>
-	    </configuration>
+            <configuration>
+              <executable>java</executable>
+              <commandlineArgs>-cp ${stylebook.classpath} org.apache.stylebook.StyleBook
+                loaderConfig=sbk:/style/loaderdesign.xml targetDirectory=./target/site/design/
+                ./stylebook/sources/xalandesign.xml ./stylebook/style
+              </commandlineArgs>
+            </configuration>
           </execution>
 
           <execution>
-	    <id>Xalan2 compiled (xsltc) documentation</id>
+            <id>Xalan2 compiled (xsltc) documentation</id>
             <phase>package</phase>
             <goals>
-	      <goal>exec</goal>
+              <goal>exec</goal>
             </goals>
-	    <configuration>
-	      <executable>java</executable>
-	      <commandlineArgs>-cp ${stylebook.classpath} org.apache.stylebook.StyleBook loaderConfig=sbk:/style/loaderdesign.xml targetDirectory=./target/site/xsltc/ ./stylebook/sources/xsltc.xml ./stylebook/style</commandlineArgs>
-	    </configuration>
+            <configuration>
+              <executable>java</executable>
+              <commandlineArgs>-cp ${stylebook.classpath} org.apache.stylebook.StyleBook
+                loaderConfig=sbk:/style/loaderdesign.xml targetDirectory=./target/site/xsltc/
+                ./stylebook/sources/xsltc.xml ./stylebook/style
+              </commandlineArgs>
+            </configuration>
           </execution>
           <execution>
-	    <id>Xalan2 interpretive documentation</id>
+            <id>Xalan2 interpretive documentation</id>
             <phase>package</phase>
             <goals>
-	      <goal>exec</goal>
+              <goal>exec</goal>
             </goals>
-	    <configuration>
-	      <executable>java</executable>
-	      <commandlineArgs>-cp ${stylebook.classpath} org.apache.stylebook.StyleBook loaderConfig=sbk:/style/loaderdesign.xml targetDirectory=./target/site/xalan ./stylebook/sources/xalan-jsite.xml ./stylebook/style</commandlineArgs>
-	    </configuration>
+            <configuration>
+              <executable>java</executable>
+              <commandlineArgs>-cp ${stylebook.classpath} org.apache.stylebook.StyleBook
+                loaderConfig=sbk:/style/loaderdesign.xml targetDirectory=./target/site/xalan
+                ./stylebook/sources/xalan-jsite.xml ./stylebook/style
+              </commandlineArgs>
+            </configuration>
           </execution>
 
-	  <!-- Diff tells me that the -jlocal output is almost
-	       identical to the -jsite output despite the slight
-	       difference in the .xml files used as their
-	       sources. (The only effective difference appears to be
-	       that -jlocal doesn't produce the index or charter
-	       documents.)  I'm not convinced that's enough difference
-	       to merit generating both, but until I better grok why
-	       this duplication was done in the first place I'm
-	       hesitant to remove it. (jkesselm, 20231105) -->
+          <!--
+            Diff tells me that the -jlocal output is almost identical to the -jsite output despite the slight difference
+            in the .xml files used as their sources. (The only effective difference appears to be that -jlocal doesn't
+            produce the index or charter documents.)  I'm not convinced that's enough difference to merit generating
+            both, but until I better grok why this duplication was done in the first place I'm hesitant to remove it.
+            (jkesselm, 20231105)
+          -->
           <execution>
-	    <id>Xalan2 interpretive documentation, local</id>
+            <id>Xalan2 interpretive documentation, local</id>
             <phase>package</phase>
             <goals>
-	      <goal>exec</goal>
+              <goal>exec</goal>
             </goals>
-	    <configuration>
-	      <executable>java</executable>
-	      <commandlineArgs>-cp ${stylebook.classpath} org.apache.stylebook.StyleBook loaderConfig=sbk:/style/loaderdesign.xml targetDirectory=./target/site/xalan/local ./stylebook/sources/xalan-jlocal.xml ./stylebook/style</commandlineArgs>
-	    </configuration>
+            <configuration>
+              <executable>java</executable>
+              <commandlineArgs>-cp ${stylebook.classpath} org.apache.stylebook.StyleBook
+                loaderConfig=sbk:/style/loaderdesign.xml targetDirectory=./target/site/xalan/local
+                ./stylebook/sources/xalan-jlocal.xml ./stylebook/style
+              </commandlineArgs>
+            </configuration>
           </execution>
         </executions>
       </plugin>
 
       <!-- Two more files to copy to the site directory -->
       <plugin>
-	<artifactId>maven-resources-plugin</artifactId>
-	<version>3.0.2</version>
-	<executions>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
           <execution>
             <id>copy-resources</id>
             <phase>package</phase>
@@ -267,13 +274,13 @@ command "mvn compile dependency:tree" so everything is in scope.
               </resources>
             </configuration>
           </execution>
-	</executions>
+        </executions>
       </plugin>
 
       <!-- Standardized Apache "source distribution" -->
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-	<version>3.6.0</version>
+        <version>3.6.0</version>
         <dependencies>
           <dependency>
             <groupId>org.apache.apache.resources</groupId>
@@ -289,12 +296,11 @@ command "mvn compile dependency:tree" so everything is in scope.
               <goal>single</goal>
             </goals>
             <configuration>
-              <!-- Use  this flag to generate source release assembly
-                  from the top of a multi modules maven project.  -->
+              <!-- Use this flag to generate source release assembly from the top of a multi modules maven project -->
               <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
               <descriptorRefs>
                 <!--
-                    There are 3 descriptors available, choose one of them:
+                  There are 3 descriptors available, choose one of them:
                     * source-release (zip only, this one is used in the ASF parent POM) 
                     * source-release-zip-tar (both zip and tar) 
                     * source-release-tar (tar only) 
@@ -305,7 +311,7 @@ command "mvn compile dependency:tree" so everything is in scope.
             </configuration>
           </execution>
         </executions>
-      </plugin>      
+      </plugin>
 
     </plugins>
   </build>
@@ -316,71 +322,73 @@ command "mvn compile dependency:tree" so everything is in scope.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.6.0</version>
-	<configuration>
+        <configuration>
 
-	  <!-- Mute "missing" javadoc errors. We have lots of 'em, and
-	       they're a distraction from simply getting the Maven
-	       build up and running. Open a jira task to fix this
-	       later. GONK. -->
-	  <doclint>none</doclint>
+          <!--
+            Mute "missing" javadoc errors. We have lots of 'em, and they're a distraction from simply getting the Maven
+            build up and running. Open a jira task to fix this later. GONK. 
+          -->
+          <doclint>none</doclint>
 
-	  <groups>
+          <groups>
             <group>
-	      <title>XPath</title>
-	      <packages>org.apache.xpath*</packages>
-	    </group>
+              <title>XPath</title>
+              <packages>org.apache.xpath*</packages>
+            </group>
             <group>
-	      <title>Document Table Model (DTM)</title>
-	      <packages>org.apache.xml.dtm*</packages>
-	    </group>          
+              <title>Document Table Model (DTM)</title>
+              <packages>org.apache.xml.dtm*</packages>
+            </group>
             <group>
-	      <title>Utilities</title>
-	      <packages>org.apache.xml.utils*</packages>
-	    </group>
+              <title>Utilities</title>
+              <packages>org.apache.xml.utils*</packages>
+            </group>
             <group>
-	      <title>Xalan Other</title>
-	      <packages>org.apache.xalan.client:org:org.apache.xalan.extensions:org.apache.xalan.res:org.apache.xalan.stree:org.apache.xalan.trace:org.apache.xalan.xslt</packages>
-	    </group>
+              <title>Xalan Other</title>
+              <packages>
+                org.apache.xalan.client:org:org.apache.xalan.extensions:org.apache.xalan.res:org.apache.xalan.stree:org.apache.xalan.trace:org.apache.xalan.xslt
+              </packages>
+            </group>
             <group>
-	      <title>Xalan Extensions</title>
-	      <packages>org.apache.xalan.lib*</packages>
-	    </group>
+              <title>Xalan Extensions</title>
+              <packages>org.apache.xalan.lib*</packages>
+            </group>
             <group>
-	      <title>Serializers</title>
-	      <packages>org.apache.xml.serialize*:org.apache.xalan.serialize</packages>
-	    </group>
+              <title>Serializers</title>
+              <packages>org.apache.xml.serialize*:org.apache.xalan.serialize</packages>
+            </group>
             <group>
-	      <title>SAX 2</title>
-	      <packages>org.xml.sax*</packages>
-	    </group>
+              <title>SAX 2</title>
+              <packages>org.xml.sax*</packages>
+            </group>
             <group>
-	      <title>DOM 2</title>
-	      <packages>org.w3c.dom*</packages>
-	    </group>
+              <title>DOM 2</title>
+              <packages>org.w3c.dom*</packages>
+            </group>
             <group>
-	      <title>XSLTC Core</title>
-	      <packages>org.apache.xalan.xsltc*</packages>
-	    </group>
-	  </groups>
+              <title>XSLTC Core</title>
+              <packages>org.apache.xalan.xsltc*</packages>
+            </group>
+          </groups>
 
-	  <!-- Locally provided taglet; see xalan2jtaglet module -->
-	  <taglets>
+          <!-- Locally provided taglet; see xalan2jtaglet module -->
+          <taglets>
             <taglet>
-	      <tagletClass>xalan2jtaglet.XSLUsageTag</tagletClass>
-	    </taglet>
-	  </taglets>
-	  <tagletArtifact>
-	    <groupId>xalan</groupId>
-	    <artifactId>xalan2jtaglet</artifactId>
-	    <version>2.7.3</version>
-	  </tagletArtifact>
+              <tagletClass>xalan2jtaglet.XSLUsageTag</tagletClass>
+            </taglet>
+          </taglets>
+          <tagletArtifact>
+            <groupId>xalan</groupId>
+            <artifactId>xalan2jtaglet</artifactId>
+            <version>2.7.3</version>
+          </tagletArtifact>
 
-	</configuration>
+        </configuration>
 
         <reportSets>
           <reportSet>
             <id>aggregate</id>
-            <inherited>false</inherited>        
+            <inherited>false</inherited>
             <reports>
               <report>aggregate</report>
             </reports>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>xalan-project</artifactId>
     <groupId>xalan</groupId>
@@ -38,23 +40,18 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/javax.servlet/servlet-api -->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
       <version>2.5</version> <!-- jakata servlet is at 6.0 -->
       <scope>provided</scope>
     </dependency>
-
-    <!-- https://mvnrepository.com/artifact/javax.ejb/ejb-api -->
     <dependency>
       <groupId>javax.ejb</groupId>
       <artifactId>ejb-api</artifactId>
       <version>3.0</version>
       <scope>provided</scope>
     </dependency>
-
-    <!-- https://mvnrepository.com/artifact/xerces/xercesImpl -->
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
@@ -62,12 +59,11 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- It isn't clear whether, or where, the Brazil server code
-	 is avalable on Maven. And I suspect the right answer is
-	 really to eliminate use of it in favor of more modern
-	 solutions. But Sun used it in their XSLTC samples, and
-	 for now I'll just continue carrying a local (ugh) copy.
-	 -->
+    <!--
+      It isn't clear whether, or where, the Brazil server code is avalable on Maven. And I suspect the right answer is
+      really to eliminate use of it in favor of more modern solutions. But Sun used it in their XSLTC samples, and for
+      now I'll just continue carrying a local (ugh) copy.
+    -->
     <dependency>
       <groupId>sunlabs</groupId>
       <artifactId>brazil</artifactId>
@@ -76,7 +72,6 @@
       <systemPath>${basedir}/lib/brazil-2.1.jar</systemPath>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.jboss.spec.javax.rmi/jboss-rmi-api_1.0_spec -->
     <dependency>
       <groupId>org.jboss.spec.javax.rmi</groupId>
       <artifactId>jboss-rmi-api_1.0_spec</artifactId>
@@ -87,45 +82,41 @@
 
   <build>
     <plugins>
-      <!--
-	  https://maven.apache.org/plugins/maven-shade-plugin/examples/includes-excludes.html -->
+      <!-- https://maven.apache.org/plugins/maven-shade-plugin/examples/includes-excludes.html -->
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-shade-plugin</artifactId>
-	<version>3.5.0</version>
-	<executions>
-	  <execution>
-	    <phase>package</phase>
-	    <goals>
-	      <goal>shade</goal>
-	    </goals>
-	    <configuration>
-	      <artifactSet>
-		<excludes>
-		  <!-- Their examples (testing) -->
-		  <exclude>junit:junit</exclude>
-		  <exclude>jmock:*</exclude>
-		  <exclude>org.apache.maven:lib:tests</exclude>
-		  <!-- What I think I need to exclude.
-		       Some are direct dependencies, some come in
-		       via maven packages. -->
-		  <exclude>com.github.vbmacher:java-cup</exclude>
-		  <exclude>commons-logging:commons-logging</exclude>
-		  <exclude>org.apache.commons:commons-lang3</exclude>
-		  <exclude>org.apache.ant:ant</exclude>
-		  <exclude>org.apache.ant:ant-launcher</exclude>
-		  <exclude>xalan:serializer</exclude>
-		  <exclude>de.jflex:jflex</exclude>	
-		  <exclude>org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec</exclude>
-		</excludes>
-	      </artifactSet>
-	    </configuration>
-	  </execution>
-	</executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <excludes>
+                  <!-- Their examples (testing) -->
+                  <exclude>junit:junit</exclude>
+                  <exclude>jmock:*</exclude>
+                  <exclude>org.apache.maven:lib:tests</exclude>
+                  <!-- What I think I need to exclude. Some are direct dependencies, some come in via Maven packages. -->
+                  <exclude>com.github.vbmacher:java-cup</exclude>
+                  <exclude>commons-logging:commons-logging</exclude>
+                  <exclude>org.apache.commons:commons-lang3</exclude>
+                  <exclude>org.apache.ant:ant</exclude>
+                  <exclude>org.apache.ant:ant-launcher</exclude>
+                  <exclude>xalan:serializer</exclude>
+                  <exclude>de.jflex:jflex</exclude>
+                  <exclude>org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec</exclude>
+                </excludes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
-      <!-- Copy generated jarfile up to xalan-java/build/,
-	   for backward compatibility with Ant builds. -->
+      <!-- Copy generated jarfile up to xalan-java/build/, for backward compatibility with Ant builds. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/serializer/pom.xml
+++ b/serializer/pom.xml
@@ -1,7 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>xalan</groupId>
     <artifactId>xalan-project</artifactId>
@@ -13,41 +14,35 @@
   <description>Apache's XML serialization layer, as used in the Xalan XSLT processor</description>
 
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/org.apache.bcel/bcel -->
     <dependency>
       <groupId>org.apache.bcel</groupId>
       <artifactId>bcel</artifactId>
       <version>6.7.0</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/commons-logging/commons-logging -->
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>1.2</version>
       <scope>provided</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/javax/javaee-api -->
     <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>
       <version>6.0</version>
       <scope>provided</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/javax.servlet/servlet-api -->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
       <version>2.5</version> <!-- jakata servlet is at 6.0 -->
       <scope>provided</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/xerces/xercesImpl -->
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
       <version>2.12.2</version>
       <scope>provided</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/xml-apis/xml-apis -->
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
@@ -61,51 +56,50 @@
     <plugins>
 
       <plugin>
-	<artifactId>maven-compiler-plugin</artifactId>
-	<version>3.8.1</version>
-	<configuration>
-	  <source>1.8</source>
-	  <target>1.8</target>
-	</configuration>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
       </plugin>
 
-      <!-- Filter out packages we don't want copied to the output jar
-	  https://maven.apache.org/plugins/maven-shade-plugin/examples/includes-excludes.html -->
+      <!--
+        Filter out packages we don't want copied to the output jar
+        https://maven.apache.org/plugins/maven-shade-plugin/examples/includes-excludes.html
+      -->
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-shade-plugin</artifactId>
-	<version>3.5.0</version>
-	<executions>
-	  <execution>
-	    <phase>package</phase>
-	    <goals>
-	      <goal>shade</goal>
-	    </goals>
-	    <configuration>
-	      <artifactSet>
-		<excludes>
-		  <!-- Their examples (testing) -->
-		  <exclude>junit:junit</exclude>
-		  <exclude>jmock:*</exclude>
-		  <exclude>org.apache.maven:lib:tests</exclude>
-		  <!-- What I think I need to exclude.
-		       Some are direct dependencies, some come in
-		       via maven packages. -->
-		  <exclude>com.github.vbmacher:java-cup</exclude>
-		  <exclude>commons-logging:commons-logging</exclude>
-		  <exclude>org.apache.commons:commons-lang3</exclude>
-		  <exclude>org.apache.ant:ant</exclude>
-		  <exclude>org.apache.ant:ant-launcher</exclude>
-		  <exclude>org.apache.bcel:bcel</exclude>
-		</excludes>
-	      </artifactSet>
-	    </configuration>
-	  </execution>
-	</executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <excludes>
+                  <!-- Their examples (testing) -->
+                  <exclude>junit:junit</exclude>
+                  <exclude>jmock:*</exclude>
+                  <exclude>org.apache.maven:lib:tests</exclude>
+                  <!-- What I think I need to exclude. Some are direct dependencies, some come in via Maven packages. -->
+                  <exclude>com.github.vbmacher:java-cup</exclude>
+                  <exclude>commons-logging:commons-logging</exclude>
+                  <exclude>org.apache.commons:commons-lang3</exclude>
+                  <exclude>org.apache.ant:ant</exclude>
+                  <exclude>org.apache.ant:ant-launcher</exclude>
+                  <exclude>org.apache.bcel:bcel</exclude>
+                </excludes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
-      <!-- Copy generated jarfile up to xalan-java/build/,
-	   for backward compatibility with Ant builds. -->
+      <!-- Copy generated jarfile up to xalan-java/build/, for backward compatibility with Ant builds. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/xalan/pom.xml
+++ b/xalan/pom.xml
@@ -1,5 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>xalan</groupId>
     <artifactId>xalan-project</artifactId>
@@ -9,41 +11,43 @@
   <artifactId>xalan</artifactId>
   <name>Apache Xalan-Java</name>
   <description>Apache's XSLT processor</description>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <resources>
       <resource>
-	<directory>META-INF</directory>
-	<includes>
-	  <include>LICENSE.txt</include>
-	  <include>NOTICE.txt</include>
-	</includes>
+        <directory>META-INF</directory>
+        <includes>
+          <include>LICENSE.txt</include>
+          <include>NOTICE.txt</include>
+        </includes>
       </resource>
       <resource>
-	<directory>src/main/resources</directory>
-	<includes>
-	  <include>**/*.properties</include>
-	</includes>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>**/*.properties</include>
+        </includes>
       </resource>
     </resources>
     <plugins>
       <plugin>
-	<artifactId>maven-compiler-plugin</artifactId>
-	<version>3.8.1</version>
-	<configuration>
-	  <source>1.8</source>
-	  <target>1.8</target>
-	</configuration>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
       </plugin>
 
-       <!-- https://github.com/vbmacher/cup-maven-plugin -->
-      <!-- NOTE: There is an XPathParser.java in both xalan/xsltc/compiler/ and
-               xpath/compiler/. THEY ARE NOT IDENTICAL. -->
-      <!-- Should .cup and .lex be in src/main/resources rather than
-	   src/main/java? -->
+      <!--
+        https://github.com/vbmacher/cup-maven-plugin
+        NOTE: There is an XPathParser.java in both xalan/xsltc/compiler/ and xpath/compiler/. THEY ARE NOT IDENTICAL.
+        Should .cup and .lex be in src/main/resources rather than src/main/java?
+      -->
       <plugin>
         <groupId>com.github.vbmacher</groupId>
         <artifactId>cup-maven-plugin</artifactId>
@@ -63,83 +67,77 @@
         </configuration>
       </plugin>
 
-      <!-- https://jflex-de.github.io/jflex-web/jflex-maven-plugin/usage.html
-	   Must run after java_cup has produced the sym.java file
-	   sym.java + xpath.lex -> xpath.lex.java, moved to XPathLexer.java
-	   It Is Claimed that JFlex is a compatible replacement for JLex.
+      <!--
+        https://jflex-de.github.io/jflex-web/jflex-maven-plugin/usage.html
+        Must run after java_cup has produced the sym.java file sym.java + xpath.lex -> xpath.lex.java, moved to
+        XPathLexer.java. It Is claimed that JFlex is a compatible replacement for JLex.
       -->
-      <!-- https://mvnrepository.com/artifact/de.jflex/jflex -->
       <plugin>
         <groupId>de.jflex</groupId>
-        <artifactId>jflex-maven-plugin</artifactId>	
-	<version>1.9.1</version>
+        <artifactId>jflex-maven-plugin</artifactId>
+        <version>1.9.1</version>
         <executions>
           <execution>
             <goals>
               <goal>generate</goal>
             </goals>
             <configuration>
-	      <jlex>true</jlex> <!-- Strict jlex compatibility? -->
+              <jlex>true</jlex> <!-- Strict jlex compatibility? -->
               <outputDirectory>src/main/java</outputDirectory>
               <lexDefinitions>
                 <lexDefinition>src/main/java/org/apache/xalan/xsltc/compiler/xpath.lex</lexDefinition>
               </lexDefinitions>
             </configuration>
-            </execution>
+          </execution>
         </executions>
       </plugin>
 
-      <!--
-	  https://maven.apache.org/plugins/maven-shade-plugin/examples/includes-excludes.html -->
+      <!-- https://maven.apache.org/plugins/maven-shade-plugin/examples/includes-excludes.html -->
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-shade-plugin</artifactId>
-	<version>3.5.0</version>
-	<executions>
-	  <execution>
-	    <phase>package</phase>
-	    <goals>
-	      <goal>shade</goal>
-	    </goals>
-	    <configuration>
-	      <artifactSet>
-		<excludes>
-		  <!-- Their examples (testing) -->
-		  <exclude>junit:junit</exclude>
-		  <exclude>jmock:*</exclude>
-		  <exclude>org.apache.maven:lib:tests</exclude>
-		  <!-- What I think I need to exclude.
-		       Some are direct dependencies, some come in
-		       via maven packages. -->
-		  <exclude>com.github.vbmacher:java-cup</exclude>
-		  <!-- java-cup-runtime, however, is needed -->
-		  <exclude>commons-logging:commons-logging</exclude>
-		  <exclude>org.apache.commons:commons-lang3</exclude>
-		  <exclude>org.apache.ant:ant</exclude>
-		  <exclude>org.apache.ant:ant-launcher</exclude>
-		  <exclude>xalan:serializer</exclude>
-		  <exclude>de.jflex:jflex</exclude>	
-		</excludes>
-	      </artifactSet>
-	    </configuration>
-	  </execution>
-	</executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <excludes>
+                  <!-- Their examples (testing) -->
+                  <exclude>junit:junit</exclude>
+                  <exclude>jmock:*</exclude>
+                  <exclude>org.apache.maven:lib:tests</exclude>
+                  <!-- What I think I need to exclude. Some are direct dependencies, some come in via Maven packages. -->
+                  <exclude>com.github.vbmacher:java-cup</exclude>
+                  <!-- java-cup-runtime, however, is needed -->
+                  <exclude>commons-logging:commons-logging</exclude>
+                  <exclude>org.apache.commons:commons-lang3</exclude>
+                  <exclude>org.apache.ant:ant</exclude>
+                  <exclude>org.apache.ant:ant-launcher</exclude>
+                  <exclude>xalan:serializer</exclude>
+                  <exclude>de.jflex:jflex</exclude>
+                </excludes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
-      <!-- Copy generated jarfile up to xalan-java/build/,
-	   for backward compatibility with Ant builds. -->
+      <!-- Copy generated jarfile up to xalan-java/build/, for backward compatibility with Ant builds. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <!-- And -source.jar -->
       <plugin>
-	<artifactId>maven-resources-plugin</artifactId>
+        <artifactId>maven-resources-plugin</artifactId>
       </plugin>
 
     </plugins>
   </build>
-
 
   <dependencies>
     <dependency>
@@ -147,64 +145,54 @@
       <artifactId>serializer</artifactId>
       <version>2.7.3</version>
     </dependency>
-
-    <!-- https://mvnrepository.com/artifact/org.apache.bcel/bcel -->
     <dependency>
       <groupId>org.apache.bcel</groupId>
       <artifactId>bcel</artifactId>
       <version>6.7.0</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/commons-logging/commons-logging -->
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>1.2</version>
       <scope>provided</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.mozilla/rhino -->
     <dependency>
       <groupId>org.mozilla</groupId>
       <artifactId>rhino</artifactId>
       <version>1.7.14</version>
       <scope>provided</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.apache.bsf/bsf-api -->
     <dependency>
       <groupId>org.apache.bsf</groupId>
       <artifactId>bsf-api</artifactId>
       <version>3.1</version>
       <scope>provided</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/javax/javaee-api -->
     <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>
       <version>6.0</version>
       <scope>provided</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/javax.servlet/servlet-api -->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
       <version>2.5</version> <!-- jakata servlet is at 6.0 -->
       <scope>provided</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/xerces/xercesImpl -->
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
       <version>2.12.2</version>
       <scope>provided</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/xml-apis/xml-apis -->
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>1.4.01</version>
       <!-- We were actually using 1.4.02 in the Ant build. -->
+      <version>1.4.01</version>
       <scope>provided</scope>
     </dependency>
-
 
     <!-- https://github.com/vbmacher/cup-maven-plugin -->
     <dependency>
@@ -225,7 +213,6 @@
       <version>1.9.1</version>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>regexp</groupId>
       <artifactId>regexp</artifactId>
@@ -233,5 +220,6 @@
     </dependency>
   </dependencies>
 
-    <!-- Brazil is needed only for xsltc sample. -->
+  <!-- Brazil is needed only for xsltc sample. -->
+
 </project>

--- a/xalan2jtaglet/pom.xml
+++ b/xalan2jtaglet/pom.xml
@@ -1,7 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>xalan</groupId>
     <artifactId>xalan-project</artifactId>
@@ -10,12 +11,13 @@
 
   <artifactId>xalan2jtaglet</artifactId>
   <name>@xsl.usage taglet</name>
-  <description>Implementation of the @xsl.usage taglet, used in the Xalan package's javadoc to indicate classes which, while public for cross-module access, are not intended to be called by end-users.</description>
+  <description>Implementation of the @xsl.usage taglet, used in the Xalan package's javadoc to indicate classes which,
+    while public for cross-module access, are not intended to be called by end-users.
+  </description>
 
-  <!-- Needs com.sun.javadoc.*, of course.  WARNING: The rules for
-       finding the tools.jar equivalent can get a bit hairy. This
-       *should* work on Linux and Windows; Mac may want the resolving
-       plugin instead.
+  <!--
+    Needs com.sun.javadoc.*, of course.  WARNING: The rules for finding the tools.jar equivalent can get a bit hairy.
+    This *should* work on Linux and Windows; Mac may want the resolving plugin instead.
   -->
   <properties>
     <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
@@ -28,53 +30,46 @@
       <scope>system</scope>
       <systemPath>${toolsjar}</systemPath>
     </dependency>
+
+    <!--
+    <dependency>
+      <groupId>org.apache.bcel</groupId>
+      <artifactId>bcel</artifactId>
+      <version>6.7.0</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+      <version>6.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version> &lt;!&ndash; jakata servlet is at 6.0 &ndash;&gt;
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
+      <version>2.12.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+      <version>1.4.01</version>
+      &lt;!&ndash; We were actually using 1.4.02 in the Ant build. &ndash;&gt;
+      <scope>provided</scope>
+    </dependency>
+    -->
+
   </dependencies>
-
-
-  <!-- <dependencies> -->
-  <!--   <!-\- https://mvnrepository.com/artifact/org.apache.bcel/bcel -\-> -->
-  <!--   <dependency> -->
-  <!--     <groupId>org.apache.bcel</groupId> -->
-  <!--     <artifactId>bcel</artifactId> -->
-  <!--     <version>6.7.0</version> -->
-  <!--   </dependency> -->
-  <!--   <!-\- https://mvnrepository.com/artifact/commons-logging/commons-logging -\-> -->
-  <!--   <dependency> -->
-  <!--     <groupId>commons-logging</groupId> -->
-  <!--     <artifactId>commons-logging</artifactId> -->
-  <!--     <version>1.2</version> -->
-  <!--     <scope>provided</scope> -->
-  <!--   </dependency> -->
-  <!--   <!-\- https://mvnrepository.com/artifact/javax/javaee-api -\-> -->
-  <!--   <dependency> -->
-  <!--     <groupId>javax</groupId> -->
-  <!--     <artifactId>javaee-api</artifactId> -->
-  <!--     <version>6.0</version> -->
-  <!--     <scope>provided</scope> -->
-  <!--   </dependency> -->
-  <!--   <!-\- https://mvnrepository.com/artifact/javax.servlet/servlet-api -\-> -->
-  <!--   <dependency> -->
-  <!--     <groupId>javax.servlet</groupId> -->
-  <!--     <artifactId>servlet-api</artifactId> -->
-  <!--     <version>2.5</version> <!-\- jakata servlet is at 6.0 -\-> -->
-  <!--     <scope>provided</scope> -->
-  <!--   </dependency> -->
-  <!--   <!-\- https://mvnrepository.com/artifact/xerces/xercesImpl -\-> -->
-  <!--   <dependency> -->
-  <!--     <groupId>xerces</groupId> -->
-  <!--     <artifactId>xercesImpl</artifactId> -->
-  <!--     <version>2.12.2</version> -->
-  <!--     <scope>provided</scope> -->
-  <!--   </dependency> -->
-  <!--   <!-\- https://mvnrepository.com/artifact/xml-apis/xml-apis -\-> -->
-  <!--   <dependency> -->
-  <!--     <groupId>xml-apis</groupId> -->
-  <!--     <artifactId>xml-apis</artifactId> -->
-  <!--     <version>1.4.01</version> -->
-  <!--     <!-\- We were actually using 1.4.02 in the Ant build. -\-> -->
-  <!--     <scope>provided</scope> -->
-  <!--   </dependency> -->
-
-  <!-- </dependencies> -->
 
 </project>


### PR DESCRIPTION
- Get rid of mixed tabs and spaces, use 2 spaces for indentation uniformly instead.
- Use line width 120 with very few exceptions.
- Use a uniform way to format multi-line XML comments, putting opening and closing tag parts on separate lines, indenting the text content by 2 spaces.

This can subsequently be the baseline for further commits, both by @kubycsolutions and external PR contributors.

Sorry for maybe seeming nitpicky, but when scrolling through the POMs in my IDE, it seemed somewhat messy and hard to parse in my limited brain. It might be a personal preference only, but I do like uniform indentation. As the Java code mostly seems to use 2 spaces and the POMs also partly followed that pattern, I chode 2 spaces too - maybe also, because that is my personal preference.