### PR TITLE
Create and populate lib directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ target/
 
 # Xalan
 build/
+lib/
 **/xsltc/compiler/XPathLexer.java
 **/xsltc/compiler/XPathParser.java
 **/xsltc/compiler/sym.java

--- a/mvnbuild.bat
+++ b/mvnbuild.bat
@@ -1,1 +1,1 @@
-mvn clean compile site package
+mvn clean package site

--- a/mvnbuild.sh
+++ b/mvnbuild.sh
@@ -1,1 +1,1 @@
-mvn clean compile site package
+mvn clean package site

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.6.1</version>
           <executions>
             <execution>
               <id>copy-artifact</id>
@@ -105,7 +106,22 @@
                     <destFileName>${project.artifactId}.${project.packaging}</destFileName>
                   </artifactItem>
                 </artifactItems>
-                <outputDirectory>../build</outputDirectory>
+                <outputDirectory>${rootlocation}/build</outputDirectory>
+              </configuration>
+            </execution>
+            <execution>
+              <id>copy-dependencies</id>
+              <phase>package</phase>
+              <goals>
+                <goal>copy-dependencies</goal>
+              </goals>
+              <configuration>
+                <outputDirectory>${rootlocation}/lib</outputDirectory>
+                <overWriteReleases>false</overWriteReleases>
+                <overWriteSnapshots>false</overWriteSnapshots>
+                <overWriteIfNewer>true</overWriteIfNewer>
+                <!-- Our own artifacts are in 'build' already -->
+                <excludeGroupIds>xalan</excludeGroupIds>
               </configuration>
             </execution>
           </executions>
@@ -118,6 +134,19 @@
             <source>1.8</source>
             <target>1.8</target>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.5.0</version>
+          <executions>
+            <execution>
+              <id>root-location</id>
+              <goals>
+                <goal>rootlocation</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -154,16 +183,21 @@
         <version>3.4.5</version>
       </plugin>
 
-      <!-- During cleaning phase, empty the ./build directory, which
-           is normally not present except in the parent module.
+      <!-- During cleaning phase, empty directories ./build and ./lib, which
+           are normally not present except in the parent module.
       -->
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <configuration>
           <filesets>
             <fileset>
               <directory>./build</directory>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+            <fileset>
+              <directory>./lib</directory>
               <followSymlinks>false</followSymlinks>
             </fileset>
           </filesets>
@@ -276,6 +310,11 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
Copy dependencies to _[root]/lib_ directory during package phase. Also Build Helper Maven Plugin to generate a property for the project root folder, using it from Maven Dependency Plugin. This can come in
handy in many situations.

@jkesselm, this should help you run the tests from _xalan-test_ against a clean Maven build, too.