### PR TITLE
Run version unit tests in isolation and assert on error logs

### DIFF
--- a/xalan/src/test/java/org/apache/xalan/VersionTest.java
+++ b/xalan/src/test/java/org/apache/xalan/VersionTest.java
@@ -17,7 +17,11 @@
  */
 package org.apache.xalan;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,11 +29,33 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Isolated("redirecting System.err is not thread-safe")
 public class VersionTest {
+  private static final PrintStream originalPrintStream = System.err;
+  private static final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+  private static final PrintStream mockPrintStream = new PrintStream(buffer, true);
+
+  @BeforeAll
+  public static void beforeAll() {
+    System.setErr(mockPrintStream);
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    System.setErr(originalPrintStream);
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    buffer.reset();
+  }
 
   @ParameterizedTest(name = "{0} -> {2}")
   @MethodSource("testReadPropertiesArgs")
@@ -59,14 +85,16 @@ public class VersionTest {
         .when(Version::getPropertiesStream)
         .thenThrow(NullPointerException.class);
       assertEquals("0.0.0", Version.readVersionNumber());
+      assertTrue(buffer.toString().contains("RuntimeException: Cannot read properties file"));
     }
   }
 
   @ParameterizedTest(name = "{0} -> {1}")
   @MethodSource("testParseVersionNumberArgs")
   public void testParseVersionNumber(
-    String inputVersion, String parsedVersion,
-    int major, int release, int maintenance, int development, boolean snapshot) {
+    String inputVersion, boolean matchSuccessful, String parsedVersion,
+    int major, int release, int maintenance, int development, boolean snapshot
+  ) {
     Version.parseVersionNumber(inputVersion);
     assertEquals(parsedVersion, Version.getVersion());
     assertEquals(major, Version.getMajorVersionNum());
@@ -74,26 +102,30 @@ public class VersionTest {
     assertEquals(maintenance, Version.getMaintenanceVersionNum());
     assertEquals(development, Version.getDevelopmentVersionNum());
     assertEquals(snapshot, Version.isSnapshot());
+    boolean cannotMatchWarningFound = buffer.toString().contains("Cannot match Xalan version");
+    assertEquals(matchSuccessful, !cannotMatchWarningFound);
   }
 
   private static Stream<Arguments> testParseVersionNumberArgs() {
     return Stream.of(
       // Pattern match
-      Arguments.of("1.2.3", "Xalan Java 1.2.3", 1, 2, 3, 0, false),
-      Arguments.of("1.2.D3", "Xalan Java 1.2.D3", 1, 2, 0, 3, false),
-      Arguments.of("1.2.3-SNAPSHOT", "Xalan Java 1.2.3-SNAPSHOT", 1, 2, 3, 0, true),
-      Arguments.of("1.2.D03-SNAPSHOT", "Xalan Java 1.2.D3-SNAPSHOT", 1, 2, 0, 3, true),
+      Arguments.of("1.2.3", true, "Xalan Java 1.2.3", 1, 2, 3, 0, false),
+      Arguments.of("1.2.D3", true, "Xalan Java 1.2.D3", 1, 2, 0, 3, false),
+      Arguments.of("1.2.3-SNAPSHOT", true, "Xalan Java 1.2.3-SNAPSHOT", 1, 2, 3, 0, true),
+      Arguments.of("1.2.D03-SNAPSHOT", true, "Xalan Java 1.2.D3-SNAPSHOT", 1, 2, 0, 3, true),
+      Arguments.of("0.0.0", true, "Xalan Java 0.0.0", 0, 0, 0, 0, false),
       // No pattern match
-      Arguments.of("", "Xalan Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("-1.2.3", "Xalan Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("-1.2.3", "Xalan Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("1. 2.3", "Xalan Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("1.2.D3x", "Xalan Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("1.2.3-XSNAPSHOT", "Xalan Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("1.2.D3-snapshot", "Xalan Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("1.2.D3-SNAPSHOT-1", "Xalan Java 0.0.0", 0, 0, 0, 0, false),
-      // Input version null
-      Arguments.of(null, "Xalan Java 0.0.0", 0, 0, 0, 0, false)
+      Arguments.of("", false, "Xalan Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("-1.2.3", false, "Xalan Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("-1.2.3", false, "Xalan Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("1. 2.3", false, "Xalan Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("1.2.D3x", false, "Xalan Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("1.2.3-XSNAPSHOT", false, "Xalan Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("1.2.D3-snapshot", false, "Xalan Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("1.2.D3-SNAPSHOT-1", false, "Xalan Java 0.0.0", 0, 0, 0, 0, false),
+      // Input version null -> cannot happen in class under test, but we know
+      // what would happen if it did
+      Arguments.of(null, true, "Xalan Java 0.0.0", 0, 0, 0, 0, false)
     );
   }
 

--- a/xalan/src/test/java/org/apache/xalan/processor/XSLProcessorVersionTest.java
+++ b/xalan/src/test/java/org/apache/xalan/processor/XSLProcessorVersionTest.java
@@ -18,21 +18,47 @@
 package org.apache.xalan.processor;
 
 import org.apache.xalan.VersionAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Isolated("redirecting System.err is not thread-safe")
 public class XSLProcessorVersionTest {
+  private static final PrintStream originalPrintStream = System.err;
+  private static final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+  private static final PrintStream mockPrintStream = new PrintStream(buffer, true);
+
+  @BeforeAll
+  public static void beforeAll() {
+    System.setErr(mockPrintStream);
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    System.setErr(originalPrintStream);
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    buffer.reset();
+  }
 
   @ParameterizedTest(name = "{0} -> {1}")
   @MethodSource("testParseVersionNumberArgs")
   public void testParseVersionNumber(
-    String inputVersion, String parsedVersion,
-    int major, int release, int maintenance, int development, boolean snapshot) {
+    String inputVersion, boolean matchSuccessful, String parsedVersion,
+    int major, int release, int maintenance, int development, boolean snapshot
+  ) {
     VersionAccessor.parseVersionNumber(inputVersion);
     assertEquals(parsedVersion, XSLProcessorVersion.getVersion());
     assertEquals(major, XSLProcessorVersion.getMajorVersionNum());
@@ -40,26 +66,30 @@ public class XSLProcessorVersionTest {
     assertEquals(maintenance, XSLProcessorVersion.getMaintenanceVersionNum());
     assertEquals(development, XSLProcessorVersion.getDevelopmentVersionNum());
     assertEquals(snapshot, XSLProcessorVersion.isSnapshot());
+    boolean cannotMatchWarningFound = buffer.toString().contains("Cannot match Xalan version");
+    assertEquals(matchSuccessful, !cannotMatchWarningFound);
   }
 
   private static Stream<Arguments> testParseVersionNumberArgs() {
     return Stream.of(
       // Pattern match
-      Arguments.of("1.2.3", "Xalan Processor Java 1.2.3", 1, 2, 3, 0, false),
-      Arguments.of("1.2.D3", "Xalan Processor Java 1.2.D3", 1, 2, 0, 3, false),
-      Arguments.of("1.2.3-SNAPSHOT", "Xalan Processor Java 1.2.3-SNAPSHOT", 1, 2, 3, 0, true),
-      Arguments.of("1.2.D03-SNAPSHOT", "Xalan Processor Java 1.2.D3-SNAPSHOT", 1, 2, 0, 3, true),
+      Arguments.of("1.2.3", true, "Xalan Processor Java 1.2.3", 1, 2, 3, 0, false),
+      Arguments.of("1.2.D3", true, "Xalan Processor Java 1.2.D3", 1, 2, 0, 3, false),
+      Arguments.of("1.2.3-SNAPSHOT", true, "Xalan Processor Java 1.2.3-SNAPSHOT", 1, 2, 3, 0, true),
+      Arguments.of("1.2.D03-SNAPSHOT", true, "Xalan Processor Java 1.2.D3-SNAPSHOT", 1, 2, 0, 3, true),
+      Arguments.of("0.0.0", true, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
       // No pattern match
-      Arguments.of("", "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("-1.2.3", "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("-1.2.3", "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("1. 2.3", "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("1.2.D3x", "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("1.2.3-XSNAPSHOT", "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("1.2.D3-snapshot", "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
-      Arguments.of("1.2.D3-SNAPSHOT-1", "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
-      // Input version null
-      Arguments.of(null, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false)
+      Arguments.of("", false, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("-1.2.3", false, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("-1.2.3", false, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("1. 2.3", false, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("1.2.D3x", false, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("1.2.3-XSNAPSHOT", false, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("1.2.D3-snapshot", false, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
+      Arguments.of("1.2.D3-SNAPSHOT-1", false, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false),
+      // Input version null -> cannot happen in class under test, but we know
+      // what would happen if it did
+      Arguments.of(null, true, "Xalan Processor Java 0.0.0", 0, 0, 0, 0, false)
     );
   }
 


### PR DESCRIPTION
Use JUnit Jupiter's `@Isolated`, because redirecting `System.err` is not thread-safe. If we have no logging framework with per-class log levels and the option to use in-memory loggers in place, the only way we can silence the test from logging stack traces and warnings to `System.err` is to redirect it to an in-memory stream and assert on its contents for verification.

I do not like this solution, but for the time being it is viable, albeit suboptimal.

@jkesselm, @vlsi, maybe this makes both of you a little happier on the expense of me being a little bit unhappier. But my heart is not in this project, so I can live with it for now.