### PR TITLE
Create javadoc and source JARs for publication to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <junit-jupiter.version>5.10.1</junit-jupiter.version>
     <!-- TODO: Upgrade to 5.x after dropping requirement to build on JDK 8 -->
     <mockito.version>4.11.0</mockito.version>
+    <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
   </properties>
 
   <modules>
@@ -286,6 +287,97 @@
           <artifactId>maven-shade-plugin</artifactId>
           <version>${maven-shade-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven-javadoc-plugin.version}</version>
+
+          <configuration>
+            <!-- Deactivate doclint checks in order to suppress errors -->
+            <doclint>none</doclint>
+            <!-- Generate class use xref, making javadocs considerably bigger,
+                 but also more informative. Just navigate to any documented
+                 class or package and click on the "Use" link between "Class"
+                 and "Tree". -->
+            <use>true</use>
+            <!-- FIXME: Why does it fail without this parameter? -->
+            <javadocVersion>8</javadocVersion>
+            <source>1.8</source>
+
+            <!-- Custom taglet. Make sure to make each module using this plugin
+                 depend on xalan:${xalan.taglet.artifactId} with scope
+                 'provided', because the dependency is only used during build
+                 time. -->
+            <taglets>
+              <taglet>
+                <tagletClass>xalan2jtaglet.XSLUsageTag</tagletClass>
+              </taglet>
+            </taglets>
+            <tagletArtifact>
+              <groupId>xalan</groupId>
+              <artifactId>${xalan.taglet.artifactId}</artifactId>
+              <version>${project.version}</version>
+            </tagletArtifact>
+
+            <!-- Group package names by topic. Empty groups will not be
+                 rendered, i.e. it does not hurt to specify all groups in the
+                 global configuration. -->
+            <groups>
+              <group>
+                <title>XPath</title>
+                <packages>org.apache.xpath*</packages>
+              </group>
+              <group>
+                <title>Document Table Model (DTM)</title>
+                <packages>org.apache.xml.dtm*</packages>
+              </group>
+              <group>
+                <title>Utilities</title>
+                <packages>org.apache.xml.utils*</packages>
+              </group>
+              <group>
+                <title>Xalan Other</title>
+                <packages>org.apache.xalan.client:org:org.apache.xalan.extensions:org.apache.xalan.res:org.apache.xalan.stree:org.apache.xalan.trace:org.apache.xalan.xslt</packages>
+              </group>
+              <group>
+                <title>Xalan Extensions</title>
+                <packages>org.apache.xalan.lib*</packages>
+              </group>
+              <group>
+                <title>Serializers</title>
+                <packages>org.apache.xml.serialize*:org.apache.xalan.serialize</packages>
+              </group>
+              <group>
+                <title>SAX 2</title>
+                <packages>org.xml.sax*</packages>
+              </group>
+              <group>
+                <title>DOM 2</title>
+                <packages>org.w3c.dom*</packages>
+              </group>
+              <group>
+                <title>XSLTC Core</title>
+                <packages>org.apache.xalan.xsltc*</packages>
+              </group>
+              <group>
+                <title>Samples</title>
+                <packages>org.apache.xalan.samples*</packages>
+              </group>
+            </groups>
+          </configuration>
+
+          <executions>
+            <execution>
+              <id>javadoc-jar</id>
+              <phase>package</phase>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+
+        </plugin>
+
       </plugins>
     </pluginManagement>
 
@@ -397,6 +489,22 @@
         <version>${project.version}</version>
       </dependency>
 
+      <!-- For javadoc generation only. Which of the two 'xalan2jtaglet*'
+           artifacts is used, is determined automatically by Maven profiles
+           based on the JDK used during the build. The result will be in
+           property ${xalan.taglet.artifactId}, which is what modules generating
+           javadocs should depend on with 'provided' scope. -->
+      <dependency>
+        <groupId>xalan</groupId>
+        <artifactId>xalan2jtaglet</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>xalan</groupId>
+        <artifactId>xalan2jtaglet_jdk9</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- Test dependencies -->
       <dependency>
         <groupId>org.junit.jupiter</groupId>
@@ -431,78 +539,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
         <configuration>
-
-          <!-- Mute "missing" javadoc errors. We have lots of 'em, and
-               they're a distraction from simply getting the Maven
-               build up and running. Open a jira task to fix this
-               later. GONK. -->
-          <doclint>none</doclint>
-
-          <groups>
-            <group>
-              <title>XPath</title>
-              <packages>org.apache.xpath*</packages>
-            </group>
-            <group>
-              <title>Document Table Model (DTM)</title>
-              <packages>org.apache.xml.dtm*</packages>
-            </group>
-            <group>
-              <title>Utilities</title>
-              <packages>org.apache.xml.utils*</packages>
-            </group>
-            <group>
-              <title>Xalan Other</title>
-              <packages>org.apache.xalan.client:org:org.apache.xalan.extensions:org.apache.xalan.res:org.apache.xalan.stree:org.apache.xalan.trace:org.apache.xalan.xslt</packages>
-            </group>
-            <group>
-              <title>Xalan Extensions</title>
-              <packages>org.apache.xalan.lib*</packages>
-            </group>
-            <group>
-              <title>Serializers</title>
-              <packages>org.apache.xml.serialize*:org.apache.xalan.serialize</packages>
-            </group>
-            <group>
-              <title>SAX 2</title>
-              <packages>org.xml.sax*</packages>
-            </group>
-            <group>
-              <title>DOM 2</title>
-              <packages>org.w3c.dom*</packages>
-            </group>
-            <group>
-              <title>XSLTC Core</title>
-              <packages>org.apache.xalan.xsltc*</packages>
-            </group>
-          </groups>
-
-          <!-- Locally provided taglet; see xalan2jtaglet and
-               xalan2jtaglet_jdk9 modules
-          -->
-          <taglets>
-            <taglet>
-              <tagletClass>xalan2jtaglet.XSLUsageTag</tagletClass>
-            </taglet>
-          </taglets>
-          <tagletArtifact>
-            <groupId>xalan</groupId>
-            <artifactId>${xalan.taglet.artifactId}</artifactId>
-            <version>${project.version}</version>
-          </tagletArtifact>
-
           <!-- FIXME: Without this exclude, the build only works if module
                       'xalan2jtaglet' was first installed locally or deployed to
                        a remote repository. I.e., we have to use something like
-                      'mvn clean install site', at least for the taglet module.
+                      'mvn clean install', at least for the taglet module.
                       'mvn clean package site' on top level is not enough for a
                        build when the local Maven repo is clean.
           -->
           <excludePackageNames>xalan2jtaglet</excludePackageNames>
-          <!-- Necessary when building on JDK 9+ -->
-          <source>1.8</source>
         </configuration>
 
         <reportSets>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <!-- TODO: Upgrade to 5.x after dropping requirement to build on JDK 8 -->
     <mockito.version>4.11.0</mockito.version>
     <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
+    <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
   </properties>
 
   <modules>
@@ -376,6 +377,21 @@
             </execution>
           </executions>
 
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${maven-source-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>source-jar</id>
+              <phase>package</phase>
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
       </plugins>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -29,6 +29,12 @@
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
     </dependency>
+    <!-- For javadoc generation only, hence 'provided' scope -->
+    <dependency>
+      <groupId>xalan</groupId>
+      <artifactId>${xalan.taglet.artifactId}</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- https://mvnrepository.com/artifact/javax.servlet/servlet-api -->
     <dependency>
@@ -78,7 +84,28 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
-
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>create-javadocs</id>
+      <activation>
+        <!--
+          Activate by default. Workaround for 'activeByDefault', which is broken
+          by design, see https://issues.apache.org/jira/browse/MNG-4917.
+        -->
+        <jdk>[1,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -106,6 +106,24 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>create-sources</id>
+      <activation>
+        <!--
+          Activate by default. Workaround for 'activeByDefault', which is broken
+          by design, see https://issues.apache.org/jira/browse/MNG-4917.
+        -->
+        <jdk>[1,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/serializer/pom.xml
+++ b/serializer/pom.xml
@@ -130,6 +130,24 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>create-sources</id>
+      <activation>
+        <!--
+          Activate by default. Workaround for 'activeByDefault', which is broken
+          by design, see https://issues.apache.org/jira/browse/MNG-4917.
+        -->
+        <jdk>[1,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/serializer/pom.xml
+++ b/serializer/pom.xml
@@ -13,6 +13,13 @@
   <description>Apache's XML serialization layer, as used in the Xalan XSLT processor</description>
 
   <dependencies>
+    <!-- For javadoc generation only, hence 'provided' scope -->
+    <dependency>
+      <groupId>xalan</groupId>
+      <artifactId>${xalan.taglet.artifactId}</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- https://mvnrepository.com/artifact/org.apache.bcel/bcel -->
     <dependency>
       <groupId>org.apache.bcel</groupId>
@@ -103,5 +110,26 @@
     </plugins>
 
   </build>
+
+  <profiles>
+    <profile>
+      <id>create-javadocs</id>
+      <activation>
+        <!--
+          Activate by default. Workaround for 'activeByDefault', which is broken
+          by design, see https://issues.apache.org/jira/browse/MNG-4917.
+        -->
+        <jdk>[1,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/xalan/pom.xml
+++ b/xalan/pom.xml
@@ -137,11 +137,16 @@
 
   </build>
 
-
   <dependencies>
     <dependency>
       <groupId>xalan</groupId>
       <artifactId>serializer</artifactId>
+    </dependency>
+    <!-- For javadoc generation only, hence 'provided' scope -->
+    <dependency>
+      <groupId>xalan</groupId>
+      <artifactId>${xalan.taglet.artifactId}</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.apache.bcel/bcel -->
@@ -249,5 +254,26 @@
     </dependency>
 
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>create-javadocs</id>
+      <activation>
+        <!--
+          Activate by default. Workaround for 'activeByDefault', which is broken
+          by design, see https://issues.apache.org/jira/browse/MNG-4917.
+        -->
+        <jdk>[1,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/xalan/pom.xml
+++ b/xalan/pom.xml
@@ -274,6 +274,24 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>create-sources</id>
+      <activation>
+        <!--
+          Activate by default. Workaround for 'activeByDefault', which is broken
+          by design, see https://issues.apache.org/jira/browse/MNG-4917.
+        -->
+        <jdk>[1,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
@jkesselm, this PR adds javadoc JAR generation to modules `xalan`, `serializer`, `samples`.

These modules are candidates for publication on Maven Central (MC) and therefore need javadoc and source (J&S) JARs by default when deploying from Maven. The fact that previous releases did not include J&S on MC, because probably they were deployed manually, does not mean that we should keep it this way and point to the distro archives for J&S. Users should be able to fetch them directly from MC and use them in their IDEs seamlessly.

J&S generation steps are wrapped in profiles `create-javadocs` and `create-sources`. It can be skipped easily by deactivating those profiles for quicker development builds.

This brings us one step closer to using a canonical release process for the three main artifacts. If we also find a place to publish the Maven site, probably to https://xalan.apache.org/xalan-j/index.html, and make the site contain all relevant information to replace the current website structure for Xalan-J (rest of Xalan is out of scope), the need for separate source and binary distros goes away completely. Nobody downloads a website dump manually anymore, people view it online. Nobody downloads J&S manually anymore either, because all IDEs can do that automatically or on demand per mouse click, improving developer experience by showing J&S inline while using the corresponding library.