### PR TITLE
Copy taglet artifacts to build dir for xalan-test

### DIFF
--- a/xalan2jtaglet/pom.xml
+++ b/xalan2jtaglet/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -26,5 +26,16 @@
       <version>0.1</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Copy generated jarfile up to xalan-java/build/,
+           for backward compatibility with Ant builds. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/xalan2jtaglet_jdk9/pom.xml
+++ b/xalan2jtaglet_jdk9/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -26,6 +26,12 @@
           <source>9</source>
           <target>9</target>
         </configuration>
+      </plugin>
+      <!-- Copy generated jarfile up to xalan-java/build/,
+           for backward compatibility with Ant builds. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
That should make it easier for the tests running in a separate Ant project to predict where to find the respective JDK 8 or 9+ taglet JARs.