### PR TITLE
XALANJ-2618 Invalid encodings in Encodings.properties

### DIFF
--- a/serializer/src/main/resources/org/apache/xml/serializer/Encodings.properties
+++ b/serializer/src/main/resources/org/apache/xml/serializer/Encodings.properties
@@ -184,50 +184,32 @@ ISO2022KR  ISO-2022-KR                            0x007F
 #
 ISO8859-1  ISO-8859-1                             0x00FF
 ISO8859_1  ISO-8859-1                             0x00FF
-8859-1     ISO-8859-1                             0x00FF
-8859_1     ISO-8859-1                             0x00FF
 #
 ISO8859-2  ISO-8859-2                             0x00A0
 ISO8859_2  ISO-8859-2                             0x00A0
-8859-2     ISO-8859-2                             0x00A0
-8859_2     ISO-8859-2                             0x00A0
 #
 # Latin Alphabet No. 3 
 ISO8859-3  ISO-8859-3                             0x00A0
 ISO8859_3  ISO-8859-3                             0x00A0
-8859-3     ISO-8859-3                             0x00A0
-8859_3     ISO-8859-3                             0x00A0
 #
 ISO8859-4  ISO-8859-4                             0x00A0
 ISO8859_4  ISO-8859-4                             0x00A0
-8859-4     ISO-8859-4                             0x00A0
-8859_4     ISO-8859-4                             0x00A0
 #
 ISO8859-5  ISO-8859-5                             0x00A0
 ISO8859_5  ISO-8859-5                             0x00A0
-8859-5     ISO-8859-5                             0x00A0
-8859_5     ISO-8859-5                             0x00A0
 #
 # Latin/Arabic Alphabet 
 ISO8859-6  ISO-8859-6                             0x00A0
 ISO8859_6  ISO-8859-6                             0x00A0
-8859-6     ISO-8859-6                             0x00A0
-8859_6     ISO-8859-6                             0x00A0
 #
 ISO8859-7  ISO-8859-7                             0x00A0
 ISO8859_7  ISO-8859-7                             0x00A0
-8859-7     ISO-8859-7                             0x00A0
-8859_7     ISO-8859-7                             0x00A0
 #
 ISO8859-8  ISO-8859-8                             0x00A0
 ISO8859_8  ISO-8859-8                             0x00A0
-8859-8     ISO-8859-8                             0x00A0
-8859_8     ISO-8859-8                             0x00A0
 #
 ISO8859-9  ISO-8859-9                             0x00CF
 ISO8859_9  ISO-8859-9                             0x00CF
-8859-9     ISO-8859-9                             0x00CF
-8859_9     ISO-8859-9                             0x00CF
 #
 ISO8859-10 ISO-8859-10                            0x007E
 ISO8859_10 ISO-8859-10                            0x007E


### PR DESCRIPTION
Encodings.properties contains invalig encodings.
Since Java 9+ it causes issues while serializing ISO-8859-1 characters

See https://issues.apache.org/jira/browse/XALANJ-2618 and https://issues.apache.org/jira/browse/XALANJ-2625