### PR TITLE
Improved encoding lookup

### DIFF
--- a/serializer/src/main/java/org/apache/xml/serializer/Encodings.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/Encodings.java
@@ -36,6 +36,12 @@ import java.util.StringTokenizer;
 /**
  * Provides information about encodings. Depends on the Java runtime
  * to provides writers for the different encodings.
+ *
+ * NOTE: When a Java or MIME names appears more than once in the
+ * encodings.properties table, priority is given to the first instance
+ * seen. For example, MIME name ISO-8859-1 will be mapped to Java name
+ * ISO8859-1, even though the file includes synonyms such as ISO8859_1
+ * and 8859-1.
  * <p>
  * This class is not a public API. It is only public because it
  * is used outside of this package.
@@ -369,9 +375,9 @@ public final class Encodings extends Object
                         mimeName = st.nextToken();
                         EncodingInfo ei = new EncodingInfo(mimeName, javaName, highChar);
                         encodingInfo_list.add(ei);
-                        _encodingTableKeyMime.put(mimeName.toUpperCase(), ei);
+                        _encodingTableKeyMime.putIfAbsent(mimeName.toUpperCase(), ei);
                         if (first)
-                            _encodingTableKeyJava.put(javaName.toUpperCase(), ei);
+                            _encodingTableKeyJava.putIfAbsent(javaName.toUpperCase(), ei);
                     }
                 }
             }

--- a/serializer/src/main/resources/org/apache/xml/serializer/Encodings.properties
+++ b/serializer/src/main/resources/org/apache/xml/serializer/Encodings.properties
@@ -37,6 +37,9 @@
 # Higher values above this char might be in the encoding, although in the 
 # case of this particular encoding there are no higher chars.
 #
+# NOTE: When a Java or MIME names appears more than once in this
+# table, priority is given to the first instance seen. For example,
+# MIME name ISO-8859-1 will be mapped to Java name ISO8859-1.
 #
 # <JAVA name encoding>, <PREFERRED name MIME>
 #


### PR DESCRIPTION
As [Cédric Damioli](https://issues.apache.org/jira/secure/ViewProfile.jspa?name=cdamioli) has pointed out, the logic in Encodings.java relied upon `Hashtable` behavior that changed between Java 1.8 and Java 17.  In different levels of java the mapping from MIME encoding name to Java encoding names could yield different results. This seems to be related to how Hashtable reacted when given a new entry with the same key as an existing one.

In particular, `encodings.properties` contains:
```ISO8859-1  ISO-8859-1                             0x00FF
ISO8859_1  ISO-8859-1                             0x00FF
8859-1     ISO-8859-1                             0x00FF
8859_1     ISO-8859-1                             0x00FF
```


The latter two "shorthand" names, despite being in the "Java name" column, are not actually synonyms for this encoding in Java, and in more recent JREs the MIME name could be mapped to one of them as easily as to the first two. The result would be that output would not be encoded properly.

The simplest fix we've found is to make that resolution explicit, by replacing`put()` with `putIfAbsent()` when building the mapping tables, so that the first mapping of the MIME encoding in the file asserts the correct Java encoding equivalent, much as the first encoding in a group of comma-separated MIME encodings is taken as the preferred mapping from the associated Java encoding. 

This fix retains the ability to accept all the existing encoding names, and to work with possible user-modified versions of the `encodings.properties` file, while giving us behavior that is correct/predictable despite the changes in Java Hashtable.

(Theoretically, we could also add the comma-separated-list behavior to the Java Encoding Name column of `encodings.properties`, reducing those four lines to one and being more directly equivalent to the handling of MIME encoding names. We might even be able to use a single Hashtable for all the keys rather than needing separate ones for the Java and MIME names. But that would go beyond least-change bug fixing; if anyone thinks it's important please feel free to add it to the Jira backlog as a low-priority feature request.)