### PR TITLE
Replace uses of StringBuffer with StringBuilder.

### DIFF
--- a/serializer/src/main/java/org/apache/xml/serializer/CharInfo.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/CharInfo.java
@@ -363,7 +363,7 @@ final class CharInfo
      */
     private boolean defineEntity(String name, char value)
     {
-        StringBuffer sb = new StringBuffer("&");
+        StringBuilder sb = new StringBuilder("&");
         sb.append(name);
         sb.append(';');
         String entityString = sb.toString();

--- a/serializer/src/main/java/org/apache/xml/serializer/SerializerBase.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/SerializerBase.java
@@ -75,7 +75,7 @@ public abstract class SerializerBase
             PKG_NAME = fullyQualifiedName.substring(0, lastDot);
         }
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < PKG_NAME.length(); i++) {
             char ch = PKG_NAME.charAt(i);
             if (ch == '.')
@@ -1365,7 +1365,7 @@ public abstract class SerializerBase
             // true if we found a URI but haven't yet processed the local name 
             boolean foundURI = false;
 
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             String uri = null;
             String localName = null;
 

--- a/serializer/src/main/java/org/apache/xml/serializer/ToStream.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/ToStream.java
@@ -2799,7 +2799,7 @@ abstract public class ToStream extends SerializerBase
       Vector v = new Vector();
       int l = s.length();
       boolean inCurly = false;
-      StringBuffer buf = new StringBuffer();
+      StringBuilder buf = new StringBuilder();
 
       // parse through string, breaking on whitespaces.  I do this instead
       // of a tokenizer so I can track whitespace inside of curly brackets,
@@ -2883,7 +2883,7 @@ abstract public class ToStream extends SerializerBase
       final int len = URI_and_localNames.size() - 1;
       if (len > 0)
       {
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < len; i += 2)
         {
           // whitspace separated "{uri1}local1 {uri2}local2 ..."

--- a/serializer/src/main/java/org/apache/xml/serializer/ToUnknownStream.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/ToUnknownStream.java
@@ -1289,7 +1289,7 @@ public final class ToUnknownStream extends SerializerBase
     {
         
         if (m_tracer != null) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
                 
             sb.append('<');
             sb.append(elementName);

--- a/serializer/src/main/java/org/apache/xml/serializer/dom3/DOM3TreeWalker.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/dom3/DOM3TreeWalker.java
@@ -512,7 +512,7 @@ final class DOM3TreeWalker {
                     // DOCTYPE internal subset via an event call, so we write it
                     // out here.
                     Writer writer = fSerializer.getWriter();
-                    StringBuffer dtd = new StringBuffer();
+                    StringBuilder dtd = new StringBuilder();
 
                     dtd.append("<!DOCTYPE ");
                     dtd.append(docTypeName);

--- a/serializer/src/main/java/org/apache/xml/serializer/dom3/LSSerializerImpl.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/dom3/LSSerializerImpl.java
@@ -1463,7 +1463,7 @@ final public class LSSerializerImpl implements DOMConfiguration, LSSerializer {
         if (origPath != null && origPath.length() != 0 && origPath.indexOf('%') != -1) {
             // Locate the escape characters
             StringTokenizer tokenizer = new StringTokenizer(origPath, "%");
-            StringBuffer result = new StringBuffer(origPath.length());
+            StringBuilder result = new StringBuilder(origPath.length());
             int size = tokenizer.countTokens();
             result.append(tokenizer.nextToken());
             for(int i = 1; i < size; ++i) {

--- a/serializer/src/main/java/org/apache/xml/serializer/dom3/NamespaceSupport.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/dom3/NamespaceSupport.java
@@ -322,7 +322,7 @@ public class NamespaceSupport {
 	}
         
         public String toString(){
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             for (int i=0;i<size;i++){
                 buf.append(prefixes[i]);
                 buf.append(" ");

--- a/serializer/src/main/java/org/apache/xml/serializer/utils/SystemIDResolver.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/utils/SystemIDResolver.java
@@ -190,7 +190,7 @@ public final class SystemIDResolver
    */
   private static String replaceChars(String str)
   {
-    StringBuffer buf = new StringBuffer(str);
+    StringBuilder buf = new StringBuilder(str);
     int length = buf.length();
     for (int i = 0; i < length; i++)
     {

--- a/serializer/src/main/java/org/apache/xml/serializer/utils/URI.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/utils/URI.java
@@ -860,7 +860,7 @@ final class URI
   public String getSchemeSpecificPart()
   {
 
-    StringBuffer schemespec = new StringBuffer();
+    StringBuilder schemespec = new StringBuilder();
 
     if (m_userinfo != null || m_host != null || m_port != -1)
     {
@@ -952,7 +952,7 @@ final class URI
                         boolean p_includeFragment)
   {
 
-    StringBuffer pathString = new StringBuffer(m_path);
+    StringBuilder pathString = new StringBuilder(m_path);
 
     if (p_includeQueryString && m_queryString != null)
     {
@@ -1348,7 +1348,7 @@ final class URI
   public String toString()
   {
 
-    StringBuffer uriSpecString = new StringBuffer();
+    StringBuilder uriSpecString = new StringBuilder();
 
     if (m_scheme != null)
     {

--- a/xalan/src/main/java/org/apache/xalan/client/XSLTProcessorApplet.java
+++ b/xalan/src/main/java/org/apache/xalan/client/XSLTProcessorApplet.java
@@ -396,7 +396,7 @@ public class XSLTProcessorApplet extends Applet
    */
   public String escapeString(String s)
   {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     int length = s.length();
 
     for (int i = 0; i < length; i++)

--- a/xalan/src/main/java/org/apache/xalan/extensions/MethodResolver.java
+++ b/xalan/src/main/java/org/apache/xalan/extensions/MethodResolver.java
@@ -294,7 +294,7 @@ public class MethodResolver
   private static String replaceDash(String name)
   {
     char dash = '-';
-    StringBuffer buff = new StringBuffer("");
+    StringBuilder buff = new StringBuilder("");
     for (int i=0; i<name.length(); i++)
     {
       if (name.charAt(i) == dash)
@@ -978,7 +978,7 @@ public class MethodResolver
 
   private static String errArgs(Object[] xsltArgs, int startingArg)
   {
-    StringBuffer returnArgs = new StringBuffer();
+    StringBuilder returnArgs = new StringBuilder();
     for (int i = startingArg; i < xsltArgs.length; i++)
     {
       if (i != startingArg)

--- a/xalan/src/main/java/org/apache/xalan/lib/ExsltBase.java
+++ b/xalan/src/main/java/org/apache/xalan/lib/ExsltBase.java
@@ -47,7 +47,7 @@ public abstract class ExsltBase
       if (value == null)
       {
         NodeList nodelist = n.getChildNodes();
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for (int i = 0; i < nodelist.getLength(); i++)
         {
           Node childNode = nodelist.item(i);

--- a/xalan/src/main/java/org/apache/xalan/lib/ExsltDatetime.java
+++ b/xalan/src/main/java/org/apache/xalan/lib/ExsltDatetime.java
@@ -1108,7 +1108,7 @@ public class ExsltDatetime
     private static String strip(String symbols, String pattern)
     {
         int i = 0;
-        StringBuffer result = new StringBuffer(pattern.length());
+        StringBuilder result = new StringBuilder(pattern.length());
 
         while (i < pattern.length())
         {

--- a/xalan/src/main/java/org/apache/xalan/lib/ExsltStrings.java
+++ b/xalan/src/main/java/org/apache/xalan/lib/ExsltStrings.java
@@ -116,7 +116,7 @@ public class ExsltStrings extends ExsltBase
    */
   public static String concat(NodeList nl)
   {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     for (int i = 0; i < nl.getLength(); i++)
     {
       Node node = nl.item(i);
@@ -149,7 +149,7 @@ public class ExsltStrings extends ExsltBase
     if (pattern == null || pattern.length() == 0)
       return "";
     
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     int len = (int)length;
     int numAdded = 0;
     int index = 0;

--- a/xalan/src/main/java/org/apache/xalan/lib/sql/SQLQueryParser.java
+++ b/xalan/src/main/java/org/apache/xalan/lib/sql/SQLQueryParser.java
@@ -301,7 +301,7 @@ public class SQLQueryParser
   {
     QueryParameter  curParm = null;
     int	            state = 0;
-    StringBuffer    tok = new StringBuffer();
+    StringBuilder tok = new StringBuilder();
     boolean         firstword = true;
 
     if (m_Parameters == null) m_Parameters = new Vector();
@@ -351,7 +351,7 @@ public class SQLQueryParser
               }
             }
             firstword = false;
-            tok = new StringBuffer();
+            tok = new StringBuilder();
             if ( ch == '\'' ) state = 1;
             else if ( ch == '?' ) state = 4;
             else state = 0;
@@ -379,7 +379,7 @@ public class SQLQueryParser
             curParm.setTypeName(tok.toString());
 //            curParm.type = map_type(curParm.typeName);
             m_Parameters.addElement(curParm);
-            tok = new StringBuffer();
+            tok = new StringBuilder();
             if ( ch == '=' ) state = 7;
             else state = 6;
           }
@@ -394,7 +394,7 @@ public class SQLQueryParser
           else if ( tok.length() > 0 )
           {
             curParm.setName(tok.toString());
-            tok = new StringBuffer();
+            tok = new StringBuilder();
             if ( ch == ']' )
             {
               //param_output.addElement(new Boolean(false));
@@ -418,7 +418,7 @@ public class SQLQueryParser
               m_hasOutput = true;
             }
 
-            tok = new StringBuffer();
+            tok = new StringBuilder();
             if ( ch == ']' )
             {
               state = 0;

--- a/xalan/src/main/java/org/apache/xalan/processor/XSLTAttributeDef.java
+++ b/xalan/src/main/java/org/apache/xalan/processor/XSLTAttributeDef.java
@@ -456,7 +456,7 @@ public class XSLTAttributeDef
         return m_setterString;
       }
 
-      StringBuffer outBuf = new StringBuffer();
+      StringBuilder outBuf = new StringBuilder();
 
       outBuf.append("set");
 
@@ -643,7 +643,7 @@ public class XSLTAttributeDef
     
 	if (retVal == StringToIntTable.INVALID_KEY) 
     {
-       StringBuffer enumNamesList = getListOfEnums();
+       StringBuilder enumNamesList = getListOfEnums();
        handleError(handler, XSLTErrorResources.INVALID_ENUM,new Object[]{name, value, enumNamesList.toString() },null);
        return null;
     }
@@ -706,7 +706,7 @@ public class XSLTAttributeDef
             if (objToReturn == null) objToReturn = qname;	
 	        
 			if (qname.getPrefix() == null) {
-	           StringBuffer enumNamesList = getListOfEnums();
+                StringBuilder enumNamesList = getListOfEnums();
 
  	           enumNamesList.append(" <qname-but-not-ncname>");
                handleError(handler,XSLTErrorResources.INVALID_ENUM,new Object[]{name, value, enumNamesList.toString() },null); 
@@ -716,7 +716,7 @@ public class XSLTAttributeDef
         }
         catch (IllegalArgumentException ie) 
         {
-           StringBuffer enumNamesList = getListOfEnums();
+            StringBuilder enumNamesList = getListOfEnums();
            enumNamesList.append(" <qname-but-not-ncname>");
            
            handleError(handler,XSLTErrorResources.INVALID_ENUM,new Object[]{name, value, enumNamesList.toString() },ie); 
@@ -725,7 +725,7 @@ public class XSLTAttributeDef
         }
         catch (RuntimeException re)
         {
-           StringBuffer enumNamesList = getListOfEnums();
+           StringBuilder enumNamesList = getListOfEnums();
            enumNamesList.append(" <qname-but-not-ncname>");
 
            handleError(handler,XSLTErrorResources.INVALID_ENUM,new Object[]{name, value, enumNamesList.toString() },re); 
@@ -1532,12 +1532,12 @@ public class XSLTAttributeDef
   }
   
   /**
-   * StringBuffer containing comma delimited list of valid values for ENUM type.
+   * StringBuilder containing comma delimited list of valid values for ENUM type.
    * Used to build error message.
    */
-  private StringBuffer getListOfEnums() 
+  private StringBuilder getListOfEnums()
   {
-     StringBuffer enumNamesList = new StringBuffer();            
+      StringBuilder enumNamesList = new StringBuilder();
      String [] enumValues = this.getEnumNames();
 
      for (int i = 0; i < enumValues.length; i++)

--- a/xalan/src/main/java/org/apache/xalan/templates/ElemNumber.java
+++ b/xalan/src/main/java/org/apache/xalan/templates/ElemNumber.java
@@ -1219,7 +1219,7 @@ public class ElemNumber extends ElemTemplateElement
           // then append the formatToken.
           else if (formatTokenizer.isLetterOrDigitAhead())
           {
-            final StringBuffer formatTokenStringBuffer = new StringBuffer(formatToken);
+            final StringBuilder formatTokenStringBuffer = new StringBuilder(formatToken);
 
             // Append the formatToken string...
             // For instance [2][1][5] with a format value of "1--1. "
@@ -1949,7 +1949,7 @@ public class ElemNumber extends ElemTemplateElement
 
     if (val <= 3999L)
     {
-      StringBuffer romanBuffer = new StringBuffer();
+      StringBuilder romanBuffer = new StringBuilder();
       do
       {
         while (val >= m_romanConvertTable[place].m_postValue)

--- a/xalan/src/main/java/org/apache/xalan/transformer/NumeratorFormatter.java
+++ b/xalan/src/main/java/org/apache/xalan/transformer/NumeratorFormatter.java
@@ -192,7 +192,7 @@ class NumeratorFormatter
 
     if (val <= 3999L)
     {
-      StringBuffer romanBuffer = new StringBuffer();
+      StringBuilder romanBuffer = new StringBuilder();
       do
       {
         while (val >= m_romanConvertTable[place].m_postValue)

--- a/xalan/src/main/java/org/apache/xalan/xslt/EnvironmentCheck.java
+++ b/xalan/src/main/java/org/apache/xalan/xslt/EnvironmentCheck.java
@@ -843,7 +843,7 @@ public class EnvironmentCheck
         XALAN1_VERSION_CLASS, ObjectFactory.findClassLoader(), true);
 
       // Found Xalan-J 1.x, grab it's version fields
-      StringBuffer buf = new StringBuffer();
+      StringBuilder buf = new StringBuilder();
       Field f = clazz.getField("PRODUCT");
 
       buf.append(f.get(null));
@@ -876,7 +876,7 @@ public class EnvironmentCheck
         XALAN2_VERSION_CLASS, ObjectFactory.findClassLoader(), true);
 
       // Found Xalan-J 2.x, grab it's version fields
-      StringBuffer buf = new StringBuffer();
+      StringBuilder buf = new StringBuilder();
       Field f = clazz.getField("S_VERSION");
       buf.append(f.get(null));
 

--- a/xalan/src/main/java/org/apache/xalan/xsltc/cmdline/Compile.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/cmdline/Compile.java
@@ -45,7 +45,7 @@ public final class Compile {
  
 
     public static void printUsage() {
-        StringBuffer vers = new StringBuffer("XSLTC version " + VERSION_MAJOR
+        StringBuilder vers = new StringBuilder("XSLTC version " + VERSION_MAJOR
                 + "." + VERSION_MINOR
                 + ((VERSION_DELTA > 0) ? ("." + VERSION_DELTA) : ("")));
         System.err.println(vers + "\n"

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/AttributeSet.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/AttributeSet.java
@@ -193,7 +193,7 @@ final class AttributeSet extends TopLevelElement {
     }
 
     public String toString() {
-	StringBuffer buf = new StringBuffer("attribute-set: ");
+	StringBuilder buf = new StringBuilder("attribute-set: ");
 	// Translate all local attributes
 	final Enumeration attributes = elements();
 	while (attributes.hasMoreElements()) {

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/AttributeValueTemplate.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/AttributeValueTemplate.java
@@ -82,7 +82,7 @@ final class AttributeValueTemplate extends AttributeValue {
           */
         String t = null;
         String lookahead = null;
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         int state = OUT_EXPR;
         
         while (tokenizer.hasMoreTokens()) {            
@@ -216,7 +216,7 @@ final class AttributeValueTemplate extends AttributeValue {
     }
 
     public String toString() {
-	final StringBuffer buffer = new StringBuffer("AVT:[");
+	final StringBuilder buffer = new StringBuilder("AVT:[");
 	final int count = elementCount();
 	for (int i = 0; i < count; i++) {
 	    buffer.append(elementAt(i).toString());

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/CallTemplate.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/CallTemplate.java
@@ -137,7 +137,7 @@ final class CallTemplate extends Instruction {
 	il.append(methodGen.loadCurrentNode());
         
         // Initialize prefix of method signature
-	StringBuffer methodSig = new StringBuffer("(" + DOM_INTF_SIG 
+	StringBuilder methodSig = new StringBuilder("(" + DOM_INTF_SIG
             + NODE_ITERATOR_SIG + TRANSLET_OUTPUT_SIG + NODE_SIG);
 	
         // If calling a simply named template, push actual arguments

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/FunctionCall.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/FunctionCall.java
@@ -787,7 +787,7 @@ class FunctionCall extends Expression {
                         il.append(arg.getType().LOAD(paramTemp[i].getIndex())));
             }
 
-	    final StringBuffer buffer = new StringBuffer();
+	    final StringBuilder buffer = new StringBuilder();
 	    buffer.append('(');
 	    for (int i = 0; i < paramTypes.length; i++) {
 		buffer.append(getSignature(paramTypes[i]));
@@ -826,7 +826,7 @@ class FunctionCall extends Expression {
 		exp.getType().translateTo(classGen, methodGen, paramTypes[i]);
 	    }
 
-	    final StringBuffer buffer = new StringBuffer();
+	    final StringBuilder buffer = new StringBuilder();
 	    buffer.append('(');
 	    for (int i = 0; i < paramTypes.length; i++) {
 		buffer.append(getSignature(paramTypes[i]));
@@ -967,7 +967,7 @@ class FunctionCall extends Expression {
      */
     static final String getSignature(Class clazz) {
 	if (clazz.isArray()) {
-	    final StringBuffer sb = new StringBuffer();
+	    final StringBuilder sb = new StringBuilder();
 	    Class cl = clazz;
 	    while (cl.isArray()) {
 		sb.append("[");
@@ -1019,7 +1019,7 @@ class FunctionCall extends Expression {
      * Compute the JVM method descriptor for the method.
      */
     static final String getSignature(Method meth) {
-	final StringBuffer sb = new StringBuffer();
+	final StringBuilder sb = new StringBuilder();
 	sb.append('(');
 	final Class[] params = meth.getParameterTypes(); // avoid clone
 	for (int j = 0; j < params.length; j++) {
@@ -1033,7 +1033,7 @@ class FunctionCall extends Expression {
      * Compute the JVM constructor descriptor for the constructor.
      */
     static final String getSignature(Constructor cons) {
-	final StringBuffer sb = new StringBuffer();
+	final StringBuilder sb = new StringBuilder();
 	sb.append('(');
 	final Class[] params = cons.getParameterTypes(); // avoid clone
 	for (int j = 0; j < params.length; j++) {
@@ -1046,7 +1046,7 @@ class FunctionCall extends Expression {
      * Return the signature of the current method
      */
     private String getMethodSignature(Vector argsType) {
- 	final StringBuffer buf = new StringBuffer(_className);
+ 	final StringBuilder buf = new StringBuilder(_className);
         buf.append('.').append(_fname.getLocalPart()).append('(');
 	  
 	int nArgs = argsType.size();	    
@@ -1068,7 +1068,7 @@ class FunctionCall extends Expression {
     protected static String replaceDash(String name)
     {
         char dash = '-';
-        StringBuffer buff = new StringBuffer("");
+        StringBuilder buff = new StringBuilder("");
         for (int i = 0; i < name.length(); i++) {
         if (i > 0 && name.charAt(i-1) == dash)
             buff.append(Character.toUpperCase(name.charAt(i)));

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/Output.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/Output.java
@@ -239,7 +239,7 @@ final class Output extends TopLevelElement {
 	    _cdata = null;
 	}
 	else {
-	    StringBuffer expandedNames = new StringBuffer();
+	    StringBuilder expandedNames = new StringBuilder();
 	    StringTokenizer tokens = new StringTokenizer(_cdata);
 
 	    // Make sure to store names in expanded form

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/Step.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/Step.java
@@ -507,7 +507,7 @@ final class Step extends RelativeLocationPath {
      * Returns a string representation of this step.
      */
     public String toString() {
-	final StringBuffer buffer = new StringBuffer("step(\"");
+	final StringBuilder buffer = new StringBuilder("step(\"");
     buffer.append(Axis.getNames(_axis)).append("\", ").append(_nodeType);
 	if (_predicates != null) {
 	    final int n = _predicates.size();

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/StepPattern.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/StepPattern.java
@@ -148,7 +148,7 @@ class StepPattern extends RelativePathPattern {
     }
 	
     public String toString() {
-	final StringBuffer buffer = new StringBuffer("stepPattern(\"");
+	final StringBuilder buffer = new StringBuilder("stepPattern(\"");
     buffer.append(Axis.getNames(_axis))
 	    .append("\", ")
 	    .append(_isEpsilon ? 

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/TestSeq.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/TestSeq.java
@@ -99,7 +99,7 @@ final class TestSeq {
      */
     public String toString() {
 	final int count = _patterns.size();
-	final StringBuffer result = new StringBuffer();
+	final StringBuilder result = new StringBuilder();
 
 	for (int i = 0; i < count; i++) {
 	    final LocationPathPattern pattern =

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/Whitespace.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/Whitespace.java
@@ -144,7 +144,7 @@ final class Whitespace extends TopLevelElement {
 
         final SymbolTable stable = parser.getSymbolTable();
         StringTokenizer list = new StringTokenizer(_elementList);
-        StringBuffer elements = new StringBuffer(Constants.EMPTYSTRING);
+        StringBuilder elements = new StringBuilder(Constants.EMPTYSTRING);
 
         while (list.hasMoreElements()) {
             String token = list.nextToken();

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/XslElement.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/XslElement.java
@@ -127,7 +127,7 @@ final class XslElement extends Instruction {
 		    }
 
 		    // Prepend prefix to local name
-		    final StringBuffer newName = new StringBuffer(prefix);
+		    final StringBuilder newName = new StringBuilder(prefix);
 		    if (prefix != EMPTYSTRING) {
 			newName.append(':');
 		    }

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/util/ErrorMsg.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/util/ErrorMsg.java
@@ -251,7 +251,7 @@ public final class ErrorMsg {
     }
 
     private String formatLine() {
-	StringBuffer result = new StringBuffer();
+	StringBuilder result = new StringBuilder();
 	if (_url != null) {
 	    result.append(_url);
 	    result.append(": ");

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/util/MethodType.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/util/MethodType.java
@@ -68,7 +68,7 @@ public final class MethodType extends Type {
     }
 
     public String toString() {
-	StringBuffer result = new StringBuffer("method{");
+	StringBuilder result = new StringBuilder("method{");
 	if (_argsType != null) {
 	    final int count = _argsType.size();
 	    for (int i=0; i<count; i++) {
@@ -92,7 +92,7 @@ public final class MethodType extends Type {
      * <code>lastArgSig</code> to the end of the argument list.
      */
     public String toSignature(String lastArgSig) {
-	final StringBuffer buffer = new StringBuffer();
+	final StringBuilder buffer = new StringBuilder();
 	buffer.append('(');
 	if (_argsType != null) {
 	    final int n = _argsType.size();

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/util/ObjectType.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/util/ObjectType.java
@@ -93,7 +93,7 @@ public final class ObjectType extends Type {
     }
 
     public String toSignature() {
-	final StringBuffer result = new StringBuffer("L");
+	final StringBuilder result = new StringBuilder("L");
 	result.append(_javaClassName.replace('.', '/')).append(';');
 	return result.toString();
     }

--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/util/Util.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/util/Util.java
@@ -82,7 +82,7 @@ public final class Util {
      */
     public static String toJavaName(String name) {
 	if (name.length() > 0) {
-	    final StringBuffer result = new StringBuffer();
+	    final StringBuilder result = new StringBuilder();
 
 	    char ch = name.charAt(0);
 	    result.append(Character.isJavaIdentifierStart(ch) ? ch : '_');
@@ -135,7 +135,7 @@ public final class Util {
 
     public static String replace(String base, String delim, String[] str) {
 	final int len = base.length();
-	final StringBuffer result = new StringBuffer();
+	final StringBuilder result = new StringBuilder();
 
 	for (int i = 0; i < len; i++) {
 	    final char ch = base.charAt(i);

--- a/xalan/src/main/java/org/apache/xalan/xsltc/dom/SimpleResultTreeImpl.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/dom/SimpleResultTreeImpl.java
@@ -630,7 +630,7 @@ public class SimpleResultTreeImpl extends EmptySerializer implements DOM, DTM
         if (_size == 1)
             _text = _textArray[0];
         else {
-            StringBuffer buffer = new StringBuffer();
+            StringBuilder buffer = new StringBuilder();
             for (int i = 0; i < _size; i++) {
                 buffer.append(_textArray[i]);
             }

--- a/xalan/src/main/java/org/apache/xalan/xsltc/runtime/BasisLibrary.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/runtime/BasisLibrary.java
@@ -319,7 +319,7 @@ public final class BasisLibrary {
 	final int froml = from.length();
 	final int valuel = value.length();
 
-	final StringBuffer result = new StringBuffer();
+	final StringBuilder result = new StringBuilder();
 	for (int j, i = 0; i < valuel; i++) {
 	    final char ch = value.charAt(i);
 	    for (j = 0; j < froml; j++) {
@@ -347,7 +347,7 @@ public final class BasisLibrary {
      */
     public static String normalize_spaceF(String value) {
 	int i = 0, n = value.length();
-	StringBuffer result = new StringBuffer();
+	StringBuilder result = new StringBuilder();
 
 	while (i < n && isWhiteSpace(value.charAt(i)))
 	    i++;
@@ -1693,7 +1693,7 @@ public final class BasisLibrary {
 
     public static String replace(String base, String delim, String[] str) {
 	final int len = base.length();
-	final StringBuffer result = new StringBuffer();
+	final StringBuilder result = new StringBuilder();
 
 	for (int i = 0; i < len; i++) {
 	    final char ch = base.charAt(i);

--- a/xalan/src/main/java/org/apache/xalan/xsltc/runtime/Hashtable.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/runtime/Hashtable.java
@@ -284,7 +284,7 @@ public class Hashtable {
     public String toString() {
 	int i;
 	int max = size() - 1;
-	StringBuffer buf = new StringBuffer();
+	StringBuilder buf = new StringBuilder();
 	Enumeration k = keys();
 	Enumeration e = elements();
 	buf.append("{");

--- a/xalan/src/main/java/org/apache/xalan/xsltc/runtime/StringValueHandler.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/runtime/StringValueHandler.java
@@ -107,7 +107,7 @@ public final class StringValueHandler extends EmptySerializer {
 
 	if (value.indexOf("?>") > 0) {
 	    final int n = value.length(); 
-	    final StringBuffer valueOfPI = new StringBuffer();
+	    final StringBuilder valueOfPI = new StringBuilder();
 
 	    for (int i = 0; i < n;) {
 		final char ch = value.charAt(i++);

--- a/xalan/src/main/java/org/apache/xalan/xsltc/trax/TemplatesHandlerImpl.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/trax/TemplatesHandlerImpl.java
@@ -258,7 +258,7 @@ public class TemplatesHandlerImpl
                 }
             }
             else {
-                StringBuffer errorMessage = new StringBuffer();
+                StringBuilder errorMessage = new StringBuilder();
                 Vector errors = _parser.getErrors();
                 final int count = errors.size();
                 for (int i = 0; i < count; i++) {

--- a/xalan/src/main/java/org/apache/xalan/xsltc/trax/TransformerImpl.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/trax/TransformerImpl.java
@@ -716,7 +716,7 @@ public final class TransformerImpl extends Transformer
 	// Return a 'null' string if no CDATA section elements were specified
 	if (cdata == null) return null;
 
-	StringBuffer result = new StringBuffer();
+	StringBuilder result = new StringBuilder();
 
 	// Get an enumeration of all the elements in the hashtable
 	Enumeration elements = cdata.keys();

--- a/xalan/src/main/java/org/apache/xml/dtm/DTMException.java
+++ b/xalan/src/main/java/org/apache/xml/dtm/DTMException.java
@@ -214,7 +214,7 @@ public class DTMException extends RuntimeException {
      */
     public String getMessageAndLocation() {
 
-        StringBuffer sbuffer = new StringBuffer();
+        StringBuilder sbuffer = new StringBuilder();
         String       message = super.getMessage();
 
         if (null != message) {
@@ -254,7 +254,7 @@ public class DTMException extends RuntimeException {
     public String getLocationAsString() {
 
         if (null != locator) {
-            StringBuffer sbuffer  = new StringBuffer();
+            StringBuilder sbuffer  = new StringBuilder();
             String       systemID = locator.getSystemId();
             int          line     = locator.getLineNumber();
             int          column   = locator.getColumnNumber();

--- a/xalan/src/main/java/org/apache/xml/dtm/ref/DTMDefaultBase.java
+++ b/xalan/src/main/java/org/apache/xml/dtm/ref/DTMDefaultBase.java
@@ -842,7 +842,7 @@ public abstract class DTMDefaultBase implements DTM
           break;
         }
 
-      StringBuffer sb=new StringBuffer();
+      StringBuilder sb=new StringBuilder();
 	  sb.append("["+nodeHandle+": "+typestring+
 				"(0x"+Integer.toHexString(getExpandedTypeID(nodeHandle))+") "+
 				getNodeNameX(nodeHandle)+" {"+getNamespaceURI(nodeHandle)+"}"+

--- a/xalan/src/main/java/org/apache/xml/utils/ListingErrorHandler.java
+++ b/xalan/src/main/java/org/apache/xml/utils/ListingErrorHandler.java
@@ -384,7 +384,7 @@ public class ListingErrorHandler implements ErrorHandler, ErrorListener
             int line = locator.getLineNumber();
             int column = locator.getColumnNumber();
             pw.println("line: " + getSourceLine(url, line));
-            StringBuffer buf = new StringBuffer("line: ");
+            StringBuilder buf = new StringBuilder("line: ");
             for (int i = 1; i < column; i++)
             {
                 buf.append(' ');

--- a/xalan/src/main/java/org/apache/xml/utils/SystemIDResolver.java
+++ b/xalan/src/main/java/org/apache/xml/utils/SystemIDResolver.java
@@ -183,7 +183,7 @@ public class SystemIDResolver
    */
   private static String replaceChars(String str)
   {
-    StringBuffer buf = new StringBuffer(str);
+    StringBuilder buf = new StringBuilder(str);
     int length = buf.length();
     for (int i = 0; i < length; i++)
     {

--- a/xalan/src/main/java/org/apache/xml/utils/URI.java
+++ b/xalan/src/main/java/org/apache/xml/utils/URI.java
@@ -880,7 +880,7 @@ public class URI implements Serializable
   public String getSchemeSpecificPart()
   {
 
-    StringBuffer schemespec = new StringBuffer();
+    StringBuilder schemespec = new StringBuilder();
 
     if (m_userinfo != null || m_host != null || m_port != -1)
     {
@@ -972,7 +972,7 @@ public class URI implements Serializable
                         boolean p_includeFragment)
   {
 
-    StringBuffer pathString = new StringBuffer(m_path);
+    StringBuilder pathString = new StringBuilder(m_path);
 
     if (p_includeQueryString && m_queryString != null)
     {
@@ -1368,7 +1368,7 @@ public class URI implements Serializable
   public String toString()
   {
 
-    StringBuffer uriSpecString = new StringBuffer();
+    StringBuilder uriSpecString = new StringBuilder();
 
     if (m_scheme != null)
     {

--- a/xalan/src/main/java/org/apache/xpath/axes/WalkerFactory.java
+++ b/xalan/src/main/java/org/apache/xpath/axes/WalkerFactory.java
@@ -1282,7 +1282,7 @@ public class WalkerFactory
   
   public static String getAnalysisString(int analysis)
   {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("count: "+getStepCount(analysis)+" ");
     if((analysis & BIT_NODETEST_ANY) != 0)
     {

--- a/xalan/src/main/java/org/apache/xpath/functions/FuncConcat.java
+++ b/xalan/src/main/java/org/apache/xpath/functions/FuncConcat.java
@@ -44,7 +44,7 @@ public class FuncConcat extends FunctionMultiArgs
   public XObject execute(XPathContext xctxt) throws javax.xml.transform.TransformerException
   {
 
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
 
     // Compiler says we must have at least two arguments.
     sb.append(m_arg0.execute(xctxt).str());

--- a/xalan/src/main/java/org/apache/xpath/functions/FuncTranslate.java
+++ b/xalan/src/main/java/org/apache/xpath/functions/FuncTranslate.java
@@ -51,7 +51,7 @@ public class FuncTranslate extends Function3Args
 
     // A vector to contain the new characters.  We'll use it to construct
     // the result string.
-    StringBuffer sbuffer = new StringBuffer();
+    StringBuilder sbuffer = new StringBuilder();
 
     for (int i = 0; i < theFirstStringLength; i++)
     {

--- a/xalan/src/main/java/org/apache/xpath/patterns/StepPattern.java
+++ b/xalan/src/main/java/org/apache/xpath/patterns/StepPattern.java
@@ -787,7 +787,7 @@ public class StepPattern extends NodeTest implements SubContextList, ExpressionO
   public String toString()
   {
 
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
 
     for (StepPattern pat = this; pat != null; pat = pat.m_relativePathPattern)
     {

--- a/xalanservlet/src/main/java/servlet/ApplyXSLT.java
+++ b/xalanservlet/src/main/java/servlet/ApplyXSLT.java
@@ -656,7 +656,7 @@ public class ApplyXSLT extends HttpServlet
       mesg = "";
     else mesg = "<B>" + mesg + "</B>";
     StringTokenizer tokens = new StringTokenizer(mesg, EOL);
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
     while (tokens.hasMoreTokens())
       strBuf.append(tokens.nextToken() + EOL + "<BR>");
     mesg = strBuf.toString();


### PR DESCRIPTION
StringBuffer is a legacy synchronized class. StringBuilder is a direct replacement to StringBuffer which generally have better performance. It's quite important for performance in fresh versions of Java which disabled/removed biased locking.