### PR TITLE
[XALAN-2430] re-add vector closure

### DIFF
--- a/xalan/src/main/java/org/apache/xalan/xsltc/compiler/Stylesheet.java
+++ b/xalan/src/main/java/org/apache/xalan/xsltc/compiler/Stylesheet.java
@@ -1253,6 +1253,19 @@ public final class Stylesheet extends SyntaxTreeNode {
 	System.out.println("=================================");	
         */
 
+    // Make sure that the vector 'input' is closed
+    for (int i = 0; i < input.size(); i++) {
+        final TopLevelElement vde = (TopLevelElement) input.elementAt(i);
+        final Vector dep  = vde.getDependencies();
+        final int depSize = (dep != null) ? dep.size() : 0;
+        for (int j = 0; j < depSize; j++) {
+            final TopLevelElement vdeVar = (TopLevelElement) dep.elementAt(j);
+            if (!input.contains(vdeVar)) {
+                input.addElement(vdeVar);
+            }
+        }
+    }
+
 	Vector result = new Vector();
 	while (input.size() > 0) {
 	    boolean changed = false;


### PR DESCRIPTION
One of the modifications done in [XALANJ-2108](https://issues.apache.org/jira/browse/XALANJ-2108) was to remove the vector closure at the start of the `resolveDependencies` function.

I have re-added the closure and verified it fixes nested variables. 

Example stylesheet:
```xslt
<?xml version="1.0" encoding="UTF-8"?>
<xsl:stylesheet version="1.0" 
                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                xmlns:ns1="http://foo/ns1" 
                xmlns:ns2="http://bar/ns2"
                exclude-result-prefixes="ns1 ns2">
  
  <xsl:output method="xml"/>
  
  <xsl:variable name="var1">
    <xsl:variable name="var2">
      <xsl:value-of select="/ns1:outer/ns2:inner"/>
    </xsl:variable>
    <xsl:value-of select="concat('Name:', $var2)"/>
  </xsl:variable>
  
  <xsl:template match="/">
    <Output xmlns="http://baz/ns3">
      <xsl:apply-templates/>
    </Output>
  </xsl:template>
  
  <xsl:template match="ns2:inner">
    <Ns1In>
      <xsl:value-of select="."></xsl:value-of>
    </Ns1In>
    <Ns1Out>
      <xsl:value-of select="$var1"/>
    </Ns1Out>
  </xsl:template>
</xsl:stylesheet>
````
input message
```xml
<ns1:outer xmlns:ns1="http://foo/ns1">
  <ns2:inner xmlns:ns2="http://bar/ns2">InputContent</ns2:inner>
</ns1:outer>
```
Before the fix this would result in a "circular loop" accusation, and after the loop the result is
```xml
<?xml version="1.0" encoding="UTF-8"?><Output xmlns="http://baz/ns3">
        <Ns1In>InputContent</Ns1In><Ns1Out>Name:InputContent</Ns1Out>
```

I have tested with all the examples in [XALANJ-2430](https://issues.apache.org/jira/browse/XALANJ-2430) and [XALANJ-2108](https://issues.apache.org/jira/browse/XALANJ-2108) to ensure I haven't readded the NPE in the latter