### PR TITLE
add more functionality to the SimpleTransform sample program

### DIFF
--- a/xalansamples/src/main/java/samples/SimpleTransform/SimpleTransform.java
+++ b/xalansamples/src/main/java/samples/SimpleTransform/SimpleTransform.java
@@ -41,32 +41,72 @@ public class SimpleTransform
     throws TransformerException, TransformerConfigurationException,
        FileNotFoundException, IOException
   {
+
+    // Grab the Name of the Stylesheet from the command line
+    String stylesheet="birds.xsl";
+    String input = "birds.xml";
+    String output = "birds.out";
+    // XSLTC as fallback
+    String factoryClassName = System.getProperty("javax.xml.transform.TransformerFactory","org.apache.xalan.xsltc.trax.TransformerFactoryImpl");
+
+    if (args.length == 0){
+       System.out.println("You may provide the path and name to a stylesheet to process birds.xml into birds.out");
+       System.out.println("Defaulting to "+stylesheet);
+    }
+    if (args.length >= 1){
+      stylesheet = args[0];
+      System.out.println("Stylesheet to use: "+stylesheet);
+    }
+    if (args.length >= 2){
+      input = args[1];
+      System.out.println("Stylesheet to use: "+stylesheet+" input: "+input);
+    }
+    if (args.length >= 3){
+      output = args[2];
+      System.out.println("Stylesheet to use: "+stylesheet+" input: "+input+" output: "+output);
+    }
+    if(args.length == 4){
+      // Known options:
+      // - org.apache.xalan.processor.TransformerFactoryImpl - The Xalan interpreted processor
+      // - org.apache.xalan.xsltc.trax.SmartTransformerFactoryImpl - The XSLTC processor
+      // - com.ibm.xtq.xslt.jaxp.compiler.TransformerFactoryImpl - The IBM XL-TXE processor in IBM Java 8
+      factoryClassName = args[3];
+      System.out.println("Stylesheet to use: "+stylesheet+" input: "+input+" output: "+output+" factory: "+factoryClassName);
+    }
+    if(args.length > 4){
+      System.out.println("Only up to four arguments allowed (stylesheet, input, output, transformerFactory)");
+      return;
+    }
+
+    // In *normal* use, we want to do this:
     // Use the static TransformerFactory.newInstance() method to instantiate
     // a TransformerFactory. The javax.xml.transform.TransformerFactory
     // system property setting determines the actual class to instantiate --
     // for Xalan, org.apache.xalan.transformer.TransformerImpl.
-    TransformerFactory tFactory = TransformerFactory.newInstance();
-
-    // Grab the Name of the Stylesheet from the command line
-    String stylesheet="birds.xml";
-    if (args.length == 0)
-    {
-       System.out.println("You must provide the path and name to a stylesheet to process birds.xml into birds.out");
-       System.out.println("Defaulting to birds.xsl");
+    /* TransformerFactory tFactory = TransformerFactory.newInstance(); */
+    // But to allow specifying the factory on the command line to support
+    // testing different functionality we're going to use the forName approach
+    final TransformerFactory tFactory;
+    try{
+      Class<?> factoryClass = Class.forName(factoryClassName);
+      tFactory = (TransformerFactory) factoryClass.newInstance();
     }
-    else
-       stylesheet = args[0];
+    catch(java.lang.ClassNotFoundException | java.lang.InstantiationException | java.lang.IllegalAccessException e){
+      e.printStackTrace();
+      return;
+    }
 
-    System.out.println("Transforming birds.xml with stylesheet "+ stylesheet);
+    System.out.println("Transforming "+input+" with stylesheet "+ stylesheet);
+    System.out.println("  Xalan Version: " + (new org.apache.xalan.Version()).getVersion());
 
     //  processes the stylesheet into a compiled Templates object.
-    Transformer transformer = tFactory.newTransformer(new StreamSource("birds.xsl"));
+    Transformer transformer = tFactory.newTransformer(new StreamSource(stylesheet));
 
     // Use the Transformer to apply the associated Templates object to
     // an XML document and write the output to a file
-    transformer.transform(new StreamSource("birds.xml"),
-              new StreamResult(new FileOutputStream("birds.out")));
+    transformer.transform(new StreamSource(input),
+              new StreamResult(new FileOutputStream(output)));
 
-    System.out.println("************* The result is in birds.out *************");
+    System.out.println("************* The result is in "+output+" *************");
   }
 }


### PR DESCRIPTION
When experimenting with stylesheets and bugs, I find I need to run the same stylesheet/xml through different engines to see what they do, with that in mind I've expanded the SimpleTransform sample program to take more arguments, so that I can e.g. run:
```
$JAVA_HOME/bin/java -cp $(ls -1 ~/Development/xalan-java/build/*.jar | tr '\n' ':') samples.SimpleTransform.SimpleTransform ~/test6.xsl ~/test6.xml test6-output.xml org.apache.xalan.xsltc.trax.TransformerFactoryImpl
```
to 
- take my selected Java
- grab all the xalan jars on classpath
- run the simpleTransform sample
- take `test6.xsl` as the stylesheet to run (defaults to `birds.xsl` to ensure backwards compatibility)
- take `test6.xml` as the input to drive the stylessheet (defaults to `birds.xml` to ensure backwards compatibility)
- output to `test6-output.xml` (defaults to `birds.out` to ensure backwards compatibility)
- use the `org.apache.xalan.xsltc.trax.TransformerFactoryImpl` to process the stylesheet/xml pair. Defaults to `javax.xml.transform.TransformerFactory` but uses `forName` instead of `getInstance` now...