### PR TITLE
Valhalla JEP 401 compatibility

### DIFF
--- a/serializer/src/main/java/org/apache/xml/serializer/OutputPropertiesFactory.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/OutputPropertiesFactory.java
@@ -183,7 +183,7 @@ public final class OutputPropertiesFactory
     private static final int S_XALAN_PREFIX_LEN = S_XALAN_PREFIX.length();
 
     /** Synchronization object for lazy initialization of the above tables. */
-    private static Integer m_synch_object = new Integer(1);
+    private static final Object m_synch_object = new Object();
 
     /** the directory in which the various method property files are located */
     private static final String PROP_DIR = SerializerBase.PKG_PATH+'/';

--- a/serializer/src/main/java/org/apache/xml/serializer/OutputPropertiesFactory.java
+++ b/serializer/src/main/java/org/apache/xml/serializer/OutputPropertiesFactory.java
@@ -183,7 +183,7 @@ public final class OutputPropertiesFactory
     private static final int S_XALAN_PREFIX_LEN = S_XALAN_PREFIX.length();
 
     /** Synchronization object for lazy initialization of the above tables. */
-    private static final Object m_synch_object = new Object();
+    private static Object m_synch_object = new Object();
 
     /** the directory in which the various method property files are located */
     private static final String PROP_DIR = SerializerBase.PKG_PATH+'/';

--- a/xalan/src/main/java/org/apache/xalan/transformer/TransformerImpl.java
+++ b/xalan/src/main/java/org/apache/xalan/transformer/TransformerImpl.java
@@ -112,7 +112,7 @@ public class TransformerImpl extends Transformer
   // or reentry while the transform is going on.
 
   /** NEEDSDOC Field m_reentryGuard          */
-  private Boolean m_reentryGuard = new Boolean(true);
+  private final Object m_reentryGuard = new Object();
 
   /**
    * This is null unless we own the stream.

--- a/xalan/src/main/java/org/apache/xalan/transformer/TransformerImpl.java
+++ b/xalan/src/main/java/org/apache/xalan/transformer/TransformerImpl.java
@@ -112,7 +112,7 @@ public class TransformerImpl extends Transformer
   // or reentry while the transform is going on.
 
   /** NEEDSDOC Field m_reentryGuard          */
-  private final Object m_reentryGuard = new Object();
+  private Object m_reentryGuard = new Object();
 
   /**
    * This is null unless we own the stream.


### PR DESCRIPTION
This small change appears to bring xalan into compliance with JEP 390[1], which was a warning in preparation for JEP 401[2] by switching synchronized Integers to Objects,  where the value of the Integer is never used, and this allows xalan dependent benchmarks, such as Dacapo xalan and fop, to run under builds of the Valhalla project[3] with --enable-preview. 

[1] https://openjdk.org/jeps/390
[2] https://openjdk.org/jeps/401
[3] https://github.com/openjdk/valhalla