### PR TITLE
Set Automatic-Module-Name to org.apache.xalan

### DIFF
--- a/xalan/pom.xml
+++ b/xalan/pom.xml
@@ -34,6 +34,17 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xalan</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
       <!-- https://github.com/vbmacher/cup-maven-plugin


### PR DESCRIPTION
As this project is still supporting JDK 8 for now I've just used the maven jar plugin to set *org.apache.xalan* as the Automatic-Module-Name. In the future Xalan should have a module-info.java for full JPMS support